### PR TITLE
Inbound metrics & transaction naming

### DIFF
--- a/packages/sdk/src/cache.ts
+++ b/packages/sdk/src/cache.ts
@@ -1,0 +1,42 @@
+import { type SpanContext } from "@opentelemetry/api"
+
+export interface SpanCache {
+  txname?: string
+  parentRemote?: boolean
+}
+
+class Cache {
+  private readonly spanCache = new Map<string, SpanCache>()
+
+  get(ctx: SpanContext): SpanCache | undefined {
+    return this.spanCache.get(Cache.key(ctx))
+  }
+
+  setParentRemote(ctx: SpanContext, parentRemote: boolean | undefined): void {
+    const cache = this.get(ctx)
+    if (cache) {
+      cache.parentRemote = parentRemote
+    } else {
+      this.spanCache.set(Cache.key(ctx), { parentRemote })
+    }
+  }
+  setTxname(ctx: SpanContext, txname: string): boolean {
+    const cache = this.get(ctx)
+    if (cache) {
+      cache.txname = txname
+      return true
+    } else {
+      this.spanCache.set(Cache.key(ctx), { txname })
+      return false
+    }
+  }
+
+  clear(ctx: SpanContext): void {
+    this.spanCache.delete(Cache.key(ctx))
+  }
+
+  private static key(ctx: SpanContext): string {
+    return `${ctx.traceId}-${ctx.spanId}`
+  }
+}
+export const cache = new Cache()

--- a/packages/sdk/src/compound-processor.ts
+++ b/packages/sdk/src/compound-processor.ts
@@ -1,0 +1,38 @@
+import { type Context } from "@opentelemetry/api"
+import {
+  type ReadableSpan,
+  type Span,
+  type SpanExporter,
+  type SpanProcessor,
+  BatchSpanProcessor,
+} from "@opentelemetry/sdk-trace-base"
+
+export class CompoundSpanProcessor extends BatchSpanProcessor {
+  constructor(
+    exporter: SpanExporter,
+    private readonly processors: SpanProcessor[],
+  ) {
+    super(exporter)
+    this.processors = processors
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    super.onStart(span, parentContext)
+    this.processors.forEach((p) => p.onStart(span, parentContext))
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this.processors.reverse().forEach((p) => p.onEnd(span))
+    super.onEnd(span)
+  }
+
+  async forceFlush(): Promise<void> {
+    await Promise.all(this.processors.reverse().map((p) => p.forceFlush()))
+    await super.forceFlush()
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(this.processors.reverse().map((p) => p.shutdown()))
+    await super.shutdown()
+  }
+}

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -5,7 +5,11 @@ import { OboeError } from "./error"
 
 const MAX_TIMEOUT = 10_000
 
-type SwoOverrides = "textMapPropagator" | "sampler" | "traceExporter"
+type SwoOverrides =
+  | "textMapPropagator"
+  | "sampler"
+  | "traceExporter"
+  | "spanProcessor"
 export interface SwoConfiguration
   extends Omit<Partial<NodeSDKConfiguration>, SwoOverrides> {
   serviceKey: string

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -5,6 +5,8 @@ import {
 } from "@opentelemetry/api"
 import { type ReadableSpan } from "@opentelemetry/sdk-trace-base"
 
+import { cache } from "./cache"
+
 const TRACE_OPTIONS_KEY = createContextKey("SWO X-Trace-Options")
 const TRACEPARENT_VERSION = "00"
 
@@ -46,5 +48,6 @@ export function parentSpanContext(span: ReadableSpan): SpanContext | undefined {
     traceFlags: spanContext.traceFlags,
     traceState: spanContext.traceState,
     spanId: parentId,
+    isRemote: cache.get(spanContext)?.parentRemote,
   }
 }

--- a/packages/sdk/src/inbound-metrics-processor.ts
+++ b/packages/sdk/src/inbound-metrics-processor.ts
@@ -1,0 +1,107 @@
+import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api"
+import { hrTimeToMicroseconds } from "@opentelemetry/core"
+import {
+  type ReadableSpan,
+  NoopSpanProcessor,
+} from "@opentelemetry/sdk-trace-base"
+import { SemanticAttributes } from "@opentelemetry/semantic-conventions"
+import * as oboe from "@swotel/bindings"
+
+import { cache } from "./cache"
+import { parentSpanContext } from "./context"
+
+export class SwoInboundMetricsSpanProcessor extends NoopSpanProcessor {
+  onEnd(span: ReadableSpan): void {
+    const context = span.spanContext()
+    const parentContext = parentSpanContext(span)
+
+    if (
+      parentContext &&
+      trace.isSpanContextValid(parentContext) &&
+      !parentContext.isRemote
+    ) {
+      return
+    }
+
+    const { isHttp, transaction, method, status, url } =
+      SwoInboundMetricsSpanProcessor.httpSpanMeta(span)
+    const hasError = span.status.code === SpanStatusCode.ERROR
+    const duration = hrTimeToMicroseconds(span.duration)
+    // TODO
+    const domain = null
+
+    let txname: string
+    if (isHttp) {
+      txname = oboe.Span.createHttpSpan({
+        transaction,
+        duration,
+        method,
+        status,
+        url,
+        domain,
+        has_error: hasError ? 1 : 0,
+      })
+    } else {
+      txname = oboe.Span.createSpan({
+        transaction,
+        duration,
+        domain,
+        has_error: hasError ? 1 : 0,
+      })
+    }
+    cache.setTxname(context, txname)
+  }
+
+  private static httpSpanMeta(span: ReadableSpan):
+    | {
+        isHttp: true
+        transaction: string
+        method: string
+        status: number
+        url: string
+      }
+    | {
+        isHttp: false
+        transaction: string
+        method: undefined
+        status: undefined
+        url: undefined
+      } {
+    if (
+      span.kind !== SpanKind.SERVER ||
+      !(SemanticAttributes.HTTP_METHOD in span.attributes)
+    ) {
+      return {
+        isHttp: false,
+        transaction: span.name,
+        method: undefined,
+        status: undefined,
+        url: undefined,
+      }
+    }
+
+    const method = String(span.attributes[SemanticAttributes.HTTP_METHOD])
+    const status = Number(
+      span.attributes[SemanticAttributes.HTTP_STATUS_CODE] ?? 0,
+    )
+    const url = String(span.attributes[SemanticAttributes.HTTP_URL])
+
+    let transaction = span.attributes[SemanticAttributes.HTTP_ROUTE]
+    if (typeof transaction !== "string") {
+      try {
+        const parsedUrl = new URL(url)
+        transaction = parsedUrl.pathname
+      } catch {
+        transaction = span.name
+      }
+    }
+
+    return {
+      isHttp: true,
+      transaction,
+      method,
+      status,
+      url,
+    }
+  }
+}

--- a/packages/sdk/src/parent-info-processor.ts
+++ b/packages/sdk/src/parent-info-processor.ts
@@ -1,0 +1,13 @@
+import { type Context, trace } from "@opentelemetry/api"
+import { type Span, NoopSpanProcessor } from "@opentelemetry/sdk-trace-base"
+
+import { cache } from "./cache"
+
+export class SwoParentInfoSpanProcessor extends NoopSpanProcessor {
+  onStart(span: Span, parentContext: Context): void {
+    const spanContext = span.spanContext()
+    const parentSpanContext = trace.getSpanContext(parentContext)
+
+    cache.setParentRemote(spanContext, parentSpanContext?.isRemote)
+  }
+}


### PR DESCRIPTION
This PR contains a few things which work together

- Span cache which holds transaction names and whether the parent span was remote
- Compound span processor based on the batch processor which runs a series of processor
- Parent info processor which stores parent span context info in the cache
- Inbound metrics processor which calls into oboe and stores the custom transaction names in the cache

With these changes submitting to the actual collector now works properly