### PR TITLE
Fix lambda trace submission

### DIFF
--- a/.yarn/versions/ea559484.yml
+++ b/.yarn/versions/ea559484.yml
@@ -1,0 +1,3 @@
+releases:
+  "@solarwinds-apm/sdk": patch
+  solarwinds-apm: patch

--- a/packages/sdk/src/patches/index.ts
+++ b/packages/sdk/src/patches/index.ts
@@ -73,7 +73,10 @@ export function patch(
   const patched = { ...configs }
   for (const [name, { patch }] of Object.entries(patches)) {
     const prefixed = `@opentelemetry/instrumentation-${name}` as const
-    patched[prefixed] = patch(configs[prefixed] ?? {}, options)
+    patched[prefixed] = (patch as Patch<InstrumentationConfig>)(
+      configs[prefixed] ?? {},
+      options,
+    )
   }
   return patched
 }

--- a/packages/sdk/src/patches/lambda.ts
+++ b/packages/sdk/src/patches/lambda.ts
@@ -20,6 +20,7 @@ import { IS_AWS_LAMBDA } from "@solarwinds-apm/module"
 import { type Patch } from "."
 
 export const patch: Patch<AwsLambdaInstrumentationConfig> = (config) => ({
+  ...config,
   enabled: config.enabled ?? IS_AWS_LAMBDA,
   disableAwsContextPropagation: config.disableAwsContextPropagation ?? true,
 })

--- a/packages/sdk/src/patches/lambda.ts
+++ b/packages/sdk/src/patches/lambda.ts
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type InstrumentationConfig } from "@opentelemetry/instrumentation"
+import { type AwsLambdaInstrumentationConfig } from "@opentelemetry/instrumentation-aws-lambda"
 import { IS_AWS_LAMBDA } from "@solarwinds-apm/module"
 
 import { type Patch } from "."
 
-export const patch: Patch<InstrumentationConfig> = (config) => ({
+export const patch: Patch<AwsLambdaInstrumentationConfig> = (config) => ({
   enabled: config.enabled ?? IS_AWS_LAMBDA,
+  disableAwsContextPropagation: config.disableAwsContextPropagation ?? true,
 })


### PR DESCRIPTION
The instrumentation was submitting broken traces since it picked up a parent span ID from X-Ray for a span that was never sent to use. Fixed by ignoring X-Ray parent propagation.