### PR TITLE
New prerelease

### DIFF
--- a/packages/bindings/npm/linux-arm64-gnu-serverless/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-arm64-gnu-serverless",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-arm64-gnu",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-arm64-musl/package.json
+++ b/packages/bindings/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-arm64-musl",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-x64-gnu-serverless/package.json
+++ b/packages/bindings/npm/linux-x64-gnu-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-x64-gnu-serverless",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-x64-gnu",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/npm/linux-x64-musl/package.json
+++ b/packages/bindings/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings-linux-x64-musl",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/bindings",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/compat",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/dependencies/package.json
+++ b/packages/dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/dependencies",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/eslint-config",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/histogram",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/instrumentations/package.json
+++ b/packages/instrumentations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/instrumentations",
-  "version": "1.0.0-pre.4",
+  "version": "1.0.0-pre.5",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/lazy/package.json
+++ b/packages/lazy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/lazy",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/module",
-  "version": "1.0.0-pre.4",
+  "version": "1.0.0-pre.5",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/rollup-config/package.json
+++ b/packages/rollup-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/rollup-config",
-  "version": "1.0.0-pre.4",
+  "version": "1.0.0-pre.5",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/sdk",
-  "version": "1.0.0-pre.9",
+  "version": "1.0.0-pre.10",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solarwinds-apm",
-  "version": "14.0.0-pre.9",
+  "version": "14.0.0-pre.10",
   "description": "OpenTelemetry-based SolarWinds APM library",
   "license": "Apache-2.0",
   "contributors": [

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarwinds-apm/test",
-  "version": "1.0.0-pre.8",
+  "version": "1.0.0-pre.9",
   "license": "Apache-2.0",
   "contributors": [
     "Raphaël Thériault <raphael.theriault@solarwinds.com>"


### PR DESCRIPTION
- Added back the ability to disable logging
- oboe 14.0.2
- Detect unsupported c-ares versions
- Best-effort attempt to never fail on legacy Node.js versions (might still crash on extremely old ones)
- Response time lambda metrics
- Improved debug logging
- Updated dependencies