### PR TITLE
Re-disable resource detection by default in Lambda

### DIFF
--- a/.yarn/versions/0ac74732.yml
+++ b/.yarn/versions/0ac74732.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: patch

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -165,7 +165,7 @@ const schema = z.object({
       swTraces: boolean.default(!IS_SERVERLESS),
       swMetrics: boolean.default(!IS_SERVERLESS),
       initMessage: boolean.default(!IS_SERVERLESS),
-      resourceDetection: boolean.default(true),
+      resourceDetection: boolean.default(!IS_SERVERLESS),
       instrumentationsDefaultDisabled: boolean.default(IS_SERVERLESS),
     })
     .default({}),


### PR DESCRIPTION
Reduces cold start a lot, not sure when this was reverted.