### PR TITLE
Don't send empty http.* attributes in metrics

### DIFF
--- a/.yarn/versions/cfc065c7.yml
+++ b/.yarn/versions/cfc065c7.yml
@@ -1,0 +1,3 @@
+releases:
+  "@solarwinds-apm/sdk": patch
+  solarwinds-apm: patch

--- a/packages/sdk/src/metrics/serverless.ts
+++ b/packages/sdk/src/metrics/serverless.ts
@@ -83,12 +83,18 @@ export function recordServerlessResponseTime(
 
   const time = hrTimeToMilliseconds(span.duration)
 
-  responseTime.record(time, {
-    [SemanticAttributes.HTTP_METHOD]: method,
-    [SemanticAttributes.HTTP_STATUS_CODE]: statusCode,
-    "sw.is_error": isError,
+  const attrs = {
     "sw.transaction": transaction ?? "unknown",
-  })
+    "sw.is_error": isError,
+  }
+  if (method) {
+    attrs[SemanticAttributes.HTTP_METHOD] = method
+  }
+  if (statusCode) {
+    attrs[SemanticAttributes.HTTP_STATUS_CODE] = statusCode
+  }
+
+  responseTime.record(time, attrs)
 }
 
 export const serverlessViews = [

--- a/packages/sdk/src/metrics/serverless.ts
+++ b/packages/sdk/src/metrics/serverless.ts
@@ -14,7 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { metrics, SpanStatusCode, ValueType } from "@opentelemetry/api"
+import {
+  type Attributes,
+  metrics,
+  SpanStatusCode,
+  ValueType,
+} from "@opentelemetry/api"
 import { hrTimeToMilliseconds } from "@opentelemetry/core"
 import { Aggregation, View } from "@opentelemetry/sdk-metrics"
 import { type ReadableSpan } from "@opentelemetry/sdk-trace-base"
@@ -83,7 +88,7 @@ export function recordServerlessResponseTime(
 
   const time = hrTimeToMilliseconds(span.duration)
 
-  const attrs = {
+  const attrs: Attributes = {
     "sw.transaction": transaction ?? "unknown",
     "sw.is_error": isError,
   }


### PR DESCRIPTION
Setting an attribute with an undefined value apparently still sends it, just without any attached value. Instead avoid setting any undefined attributes.