### PR TITLE
Simplify ESlint config and warn for deprecations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,7 @@ updates:
         patterns:
           - "eslint"
           - "prettier"
+          - "typescript-eslint"
           - "@eslint/*"
           - "eslint-*"
           - "@typescript-eslint/*"

--- a/.yarn/versions/dba65c32.yml
+++ b/.yarn/versions/dba65c32.yml
@@ -1,0 +1,15 @@
+releases:
+  "@solarwinds-apm/eslint-config": minor
+  "@solarwinds-apm/sdk": patch
+
+declined:
+  - "@solarwinds-apm/bindings"
+  - "@solarwinds-apm/compat"
+  - "@solarwinds-apm/dependencies"
+  - "@solarwinds-apm/histogram"
+  - "@solarwinds-apm/instrumentations"
+  - "@solarwinds-apm/lazy"
+  - "@solarwinds-apm/module"
+  - "@solarwinds-apm/rollup-config"
+  - solarwinds-apm
+  - "@solarwinds-apm/test"

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -20,6 +20,7 @@ const prettier = require("eslint-config-prettier")
 const imports = require("eslint-plugin-simple-import-sort")
 const header = require("eslint-plugin-header")
 const tsdoc = require("eslint-plugin-tsdoc")
+const deprecation = require("eslint-plugin-deprecation")
 const globals = require("globals")
 
 const noticeTemplate = `
@@ -61,7 +62,7 @@ const unusedOptions = {
   ignoreRestSiblings: false,
 }
 
-module.exports = [
+module.exports = ts.config(
   // dist folder is always generated
   { ignores: ["dist/**"] },
   // extend from eslint's recommendations as a baseline
@@ -77,35 +78,34 @@ module.exports = [
       "no-unused-vars": ["warn", unusedOptions],
     },
   },
-  // ts files use the typescript-eslint helper
-  ...ts
-    .config(
+  // ts files use typescript-eslint and some extra rules
+  {
+    files: ["**/*.ts"],
+    extends: [
       ...ts.configs.strictTypeChecked,
       ...ts.configs.stylisticTypeChecked,
-      {
-        languageOptions: {
-          parserOptions: {
-            project: true,
-            EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
-          },
-        },
-        plugins: { tsdoc },
-        rules: {
-          "@typescript-eslint/no-non-null-assertion": "off",
-          "@typescript-eslint/no-unused-vars": ["warn", unusedOptions],
-          "@typescript-eslint/consistent-type-imports": [
-            "warn",
-            {
-              prefer: "type-imports",
-              fixStyle: "inline-type-imports",
-              disallowTypeAnnotations: false,
-            },
-          ],
-          "tsdoc/syntax": "warn",
-        },
+    ],
+    languageOptions: {
+      parserOptions: {
+        EXPERIMENTAL_useProjectService: true,
       },
-    )
-    .map((config) => ({ ...config, files: ["**/*.ts"] })),
+    },
+    plugins: { tsdoc, deprecation },
+    rules: {
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/no-unused-vars": ["warn", unusedOptions],
+      "@typescript-eslint/consistent-type-imports": [
+        "warn",
+        {
+          prefer: "type-imports",
+          fixStyle: "inline-type-imports",
+          disallowTypeAnnotations: false,
+        },
+      ],
+      "tsdoc/syntax": "warn",
+      "deprecation/deprecation": "warn",
+    },
+  },
   // imports and license notices
   {
     files: ["**/*.js", "**/*.ts"],
@@ -118,4 +118,4 @@ module.exports = [
   },
   // disable rules that conflict with prettier
   prettier,
-]
+)

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@eslint/js": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-deprecation": "^2.0.0",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "eslint-plugin-tsdoc": "^0.2.17",

--- a/packages/sdk/src/metric-exporter.ts
+++ b/packages/sdk/src/metric-exporter.ts
@@ -29,8 +29,8 @@ import {
   type ExponentialHistogram,
   ExponentialHistogramAggregation,
   type Histogram,
-  type InstrumentDescriptor,
   InstrumentType,
+  type MetricDescriptor,
   type PushMetricExporter,
   type ResourceMetrics,
 } from "@opentelemetry/sdk-metrics"
@@ -255,7 +255,7 @@ export class SwMetricsExporter implements PushMetricExporter {
   }
 
   private static descriptorTags(
-    descriptor: InstrumentDescriptor,
+    descriptor: MetricDescriptor,
   ): Record<string, string> {
     return {
       description: descriptor.description,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,6 +1875,7 @@ __metadata:
     "@eslint/js": "npm:^8.51.0"
     eslint: "npm:^8.50.0"
     eslint-config-prettier: "npm:^9.0.0"
+    eslint-plugin-deprecation: "npm:^2.0.0"
     eslint-plugin-header: "npm:^3.1.1"
     eslint-plugin-simple-import-sort: "npm:^12.0.0"
     eslint-plugin-tsdoc: "npm:^0.2.17"
@@ -2800,6 +2801,23 @@ __metadata:
   peerDependencies:
     eslint: ^8.56.0
   checksum: 10c0/b4ae9a36393c92b332e99d70219d1ee056271261f7433924db804e5f06d97ca60408b9c7a655afce8a851982e7153243a625d6cc76fea764f767f96c8f3e16da
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^6.0.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/utils@npm:6.21.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@types/json-schema": "npm:^7.0.12"
+    "@types/semver": "npm:^7.5.0"
+    "@typescript-eslint/scope-manager": "npm:6.21.0"
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/typescript-estree": "npm:6.21.0"
+    semver: "npm:^7.5.4"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 10c0/ab2df3833b2582d4e5467a484d08942b4f2f7208f8e09d67de510008eb8001a9b7460f2f9ba11c12086fd3cdcac0c626761c7995c2c6b5657d5fa6b82030a32d
   languageName: node
   linkType: hard
 
@@ -4198,6 +4216,20 @@ __metadata:
     eslint:
       optional: true
   checksum: 10c0/c7a8d1a58d76ec8217a8fea49271ec8132d1b9390965a75f6a4ecbc9e5983d742195b46d2e4378231d2186801439fe1aa5700714b0bfd4eb17aac6e1b65309df
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-deprecation@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "eslint-plugin-deprecation@npm:2.0.0"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^6.0.0"
+    tslib: "npm:^2.3.1"
+    tsutils: "npm:^3.21.0"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+    typescript: ^4.2.4 || ^5.0.0
+  checksum: 10c0/6b9cb65ecd3e98d29683bb9b7e5af01e8ac8acadacc313e18757b8120c3850a5a11bfea67f3203975a82e018ea1c07d79dabe20ade921658e8bc03c736469079
   languageName: node
   linkType: hard
 
@@ -7938,10 +7970,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
+"tslib@npm:^1.8.1":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10c0/e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
+  languageName: node
+  linkType: hard
+
+"tsutils@npm:^3.21.0":
+  version: 3.21.0
+  resolution: "tsutils@npm:3.21.0"
+  dependencies:
+    tslib: "npm:^1.8.1"
+  peerDependencies:
+    typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+  checksum: 10c0/02f19e458ec78ead8fffbf711f834ad8ecd2cc6ade4ec0320790713dccc0a412b99e7fd907c4cda2a1dc602c75db6f12e0108e87a5afad4b2f9e90a24cabd5a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Realised the config could be made cleaner and also wanted warning for deprecations since the next OTel update deprecates a bunch of things and I'd like to see them clearly in my editor and CI.

Also puts the `typescript-eslint` package in the proper dependabot group.