### PR TITLE
Don't lint when publishing testing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - run: corepack enable
 
       - run: yarn install --immutable
+      - run: yarn lint
       - run: yarn publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,7 +47,6 @@ jobs:
           yarn install
           yarn version:testing
           yarn install
-          yarn lint:fix
 
       - run: yarn publish
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lambda": "node scripts/lambda.js",
     "lint": "prettier --check *.json *.md .github && turbo run lint --continue",
     "lint:fix": "prettier --write *.json *.md .github && turbo run lint:fix --continue",
-    "publish": "turbo run build && turbo run lint && turbo run publish",
+    "publish": "turbo run build && turbo run publish",
     "test": "turbo run test --continue",
     "version:latest": "node scripts/version.js",
     "version:prerelease": "node scripts/version.js pre",


### PR DESCRIPTION
It's not necessary and caused some issues since the package names change