### PR TITLE
Publish with provenance using npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
       - run: corepack enable
 
       - run: yarn install --immutable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - run: yarn lint
       - run: yarn publish
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Export version
         id: version

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,8 +11,6 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
-      YARN_NPM_AUTH_TOKEN: ${{ github.token }}
-      YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://npm.pkg.github.com
       - run: corepack enable
 
       - uses: actions/cache@v4
@@ -49,6 +48,8 @@ jobs:
           yarn install
 
       - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Export version
         id: version

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules/
 # Turborepo cache
 .turbo/
 
+# Package archives
+package.tgz
+
 # Common build outputs
 *.tsbuildinfo
 *.log

--- a/.yarn/versions/49369b77.yml
+++ b/.yarn/versions/49369b77.yml
@@ -1,0 +1,15 @@
+declined:
+  - "@solarwinds-apm/bindings"
+  - "@solarwinds-apm/compat"
+  - "@solarwinds-apm/dependencies"
+  - "@solarwinds-apm/eslint-config"
+  - "@solarwinds-apm/histogram"
+  - "@solarwinds-apm/instrumentations"
+  - "@solarwinds-apm/lazy"
+  - "@solarwinds-apm/module"
+  - "@solarwinds-apm/proto"
+  - "@solarwinds-apm/rollup-config"
+  - "@solarwinds-apm/sampling"
+  - "@solarwinds-apm/sdk"
+  - solarwinds-apm
+  - "@solarwinds-apm/test"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,7 @@ initScope: "@solarwinds-apm"
 initFields:
   license: Apache-2.0
   publishConfig:
+    access: public
     provenance: true
 
 nodeLinker: node-modules

--- a/packages/bindings/npm/linux-arm64-gnu-serverless/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu-serverless/package.json
@@ -24,6 +24,7 @@
     "liboboe.so"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "engines": {

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -25,6 +25,7 @@
     "liboboe.so"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "engines": {

--- a/packages/bindings/npm/linux-arm64-musl/package.json
+++ b/packages/bindings/npm/linux-arm64-musl/package.json
@@ -25,6 +25,7 @@
     "liboboe.so"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "engines": {

--- a/packages/bindings/npm/linux-x64-gnu-serverless/package.json
+++ b/packages/bindings/npm/linux-x64-gnu-serverless/package.json
@@ -24,6 +24,7 @@
     "liboboe.so"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "engines": {

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -25,6 +25,7 @@
     "liboboe.so"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "engines": {

--- a/packages/bindings/npm/linux-x64-musl/package.json
+++ b/packages/bindings/npm/linux-x64-musl/package.json
@@ -25,6 +25,7 @@
     "liboboe.so"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "engines": {

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -27,6 +27,7 @@
     "./types/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -26,6 +26,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/dependencies/package.json
+++ b/packages/dependencies/package.json
@@ -26,6 +26,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,6 +22,7 @@
     "./index.js"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -26,6 +26,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/instrumentations/COMPATIBILITY.md
+++ b/packages/instrumentations/COMPATIBILITY.md
@@ -33,7 +33,7 @@
 | `koa`                       | `>=2.0.0 <3.0.0`      | `@opentelemetry/instrumentation-koa`              |
 | `lru-memoizer`              | `>=1.3.0 <3.0.0`      | `@opentelemetry/instrumentation-lru-memoizer`     |
 | `memcached`                 | `>=2.2.0`             | `@opentelemetry/instrumentation-memcached`        |
-| `mongodb`                   | `>=3.3.0 <6.4.0`      | `@opentelemetry/instrumentation-mongodb`          |
+| `mongodb`                   | `>=3.3.0 <7.0.0`      | `@opentelemetry/instrumentation-mongodb`          |
 | `mongoose`                  | `>=5.9.7 <7.0.0`      | `@opentelemetry/instrumentation-mongoose`         |
 | `mysql`                     | `>=2.0.0 <3.0.0`      | `@opentelemetry/instrumentation-mysql`            |
 | `mysql2`                    | `>=1.4.2 <4.0.0`      | `@opentelemetry/instrumentation-mysql2`           |

--- a/packages/instrumentations/package.json
+++ b/packages/instrumentations/package.json
@@ -26,6 +26,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/lazy/package.json
+++ b/packages/lazy/package.json
@@ -26,6 +26,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -30,6 +30,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -26,6 +26,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/rollup-config/package.json
+++ b/packages/rollup-config/package.json
@@ -22,6 +22,7 @@
     "./index.js"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/sampling/package.json
+++ b/packages/sampling/package.json
@@ -26,6 +26,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,6 +25,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -47,6 +47,7 @@
     "./CONFIGURATION.md"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -35,6 +35,7 @@
     "./dist/"
   ],
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "scripts": {

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -39,7 +39,7 @@ if (publishedVersions.includes(version)) {
   process.exit()
 }
 
-let command = "yarn npm publish"
+let command = "yarn pack && npm publish package.tgz"
 if (version.includes("pre")) {
   command += " --tag prerelease"
 }


### PR DESCRIPTION
This makes it so that our published package have [provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/) information so that customers know they come from us and how they were built. Yarn doesn't support it yet so the workflow is changed to use npm to publish the package archive.