### PR TITLE
Small bugfixes

### DIFF
--- a/.yarn/versions/5a072558.yml
+++ b/.yarn/versions/5a072558.yml
@@ -1,0 +1,4 @@
+releases:
+  "@solarwinds-apm/instrumentations": patch
+  "@solarwinds-apm/sdk": patch
+  solarwinds-apm: patch

--- a/packages/instrumentations/src/index.ts
+++ b/packages/instrumentations/src/index.ts
@@ -195,12 +195,17 @@ export function getInstrumentations(
     .map(([name, config]) => {
       // instantiate the instrumentation class exported from package
       const instantiate = (loaded: unknown) => {
-        const Class = (
-          loaded as Record<
-            string,
-            new (config: InstrumentationConfig) => Instrumentation
-          >
-        )[INSTRUMENTATION_NAMES[name]!]!
+        const Class =
+          typeof loaded === "function"
+            ? // instrumentation class is the single default export
+              (loaded as new (config: InstrumentationConfig) => Instrumentation)
+            : // multiple exports, retrieve by name
+              (
+                loaded as Record<
+                  string,
+                  new (config: InstrumentationConfig) => Instrumentation
+                >
+              )[INSTRUMENTATION_NAMES[name]!]!
         return new Class(config)
       }
 

--- a/packages/sdk/src/patches/winston.ts
+++ b/packages/sdk/src/patches/winston.ts
@@ -28,4 +28,5 @@ export const patch: Patch<WinstonInstrumentationConfig> = (
     record[RESOURCE_SERVICE_NAME] = options.serviceName
     config.logHook?.(span, record)
   },
+  disableLogSending: config.disableLogSending ?? true,
 })

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -20,7 +20,7 @@ import * as process from "node:process"
 
 import { DiagLogLevel } from "@opentelemetry/api"
 import { getEnvWithoutDefaults } from "@opentelemetry/core"
-import { InstrumentationBase } from "@opentelemetry/instrumentation"
+import { type Instrumentation } from "@opentelemetry/instrumentation"
 import { View } from "@opentelemetry/sdk-metrics"
 import { oboe } from "@solarwinds-apm/bindings"
 import { type InstrumentationConfigMap } from "@solarwinds-apm/instrumentations"
@@ -122,7 +122,7 @@ const transactionSettings = z.array(
 
 interface Instrumentations {
   configs?: InstrumentationConfigMap
-  extra?: InstrumentationBase[]
+  extra?: Instrumentation[]
 }
 
 interface Metrics {
@@ -147,7 +147,7 @@ const schema = z.object({
   instrumentations: z
     .object({
       configs: z.record(z.unknown()).optional(),
-      extra: z.array(z.instanceof(InstrumentationBase)).optional(),
+      extra: z.array(z.unknown()).optional(),
     })
     .transform((i) => i as Instrumentations)
     .default({}),


### PR DESCRIPTION
- Fixes some instrumentations not properly loading in CommonJS by instantiating the main export if it's a class.
- Fixes config validation errors when providing custom instrumentations that don't necessarily extend `InstrumentationBase`
- Fixes new winston instrumentation attempting to use a package that's not installed to export logs via OTel