### PR TITLE
Core parent-based sampling logic

### DIFF
--- a/.yarn/versions/487a1296.yml
+++ b/.yarn/versions/487a1296.yml
@@ -1,0 +1,17 @@
+releases:
+  "@solarwinds-apm/eslint-config": patch
+  "@solarwinds-apm/sampling": minor
+
+declined:
+  - "@solarwinds-apm/bindings"
+  - "@solarwinds-apm/compat"
+  - "@solarwinds-apm/dependencies"
+  - "@solarwinds-apm/histogram"
+  - "@solarwinds-apm/instrumentations"
+  - "@solarwinds-apm/lazy"
+  - "@solarwinds-apm/module"
+  - "@solarwinds-apm/proto"
+  - "@solarwinds-apm/rollup-config"
+  - "@solarwinds-apm/sdk"
+  - solarwinds-apm
+  - "@solarwinds-apm/test"

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -102,6 +102,7 @@ module.exports = ts.config(
           disallowTypeAnnotations: false,
         },
       ],
+      "@typescript-eslint/prefer-literal-enum-member": "off",
       "@typescript-eslint/restrict-template-expressions": [
         "warn",
         {

--- a/packages/sampling/package.json
+++ b/packages/sampling/package.json
@@ -36,7 +36,19 @@
     "release": "node ../../scripts/publish.js",
     "test": "swtest -p test/tsconfig.json -c src"
   },
+  "dependencies": {
+    "@opentelemetry/sdk-trace-base": "~1.23.0"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.3.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": false
+    }
+  },
   "devDependencies": {
+    "@opentelemetry/api": "^1.3.0",
     "@solarwinds-apm/eslint-config": "workspace:^",
     "@solarwinds-apm/rollup-config": "workspace:^",
     "@solarwinds-apm/test": "workspace:^",

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -103,7 +103,7 @@ export abstract class OboeSampler implements Sampler {
 
     const traceState = parentSpan?.spanContext().traceState?.get("sw")
     if (traceState && TRACESTATE_REGEXP.test(traceState)) {
-      this.logger.debug("context is valid for parent based sampling")
+      this.logger.debug("context is valid for parent-based sampling")
 
       if (settings.flags & Flags.SAMPLE_THROUGH_ALWAYS) {
         this.logger.debug(

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -147,14 +147,10 @@ export abstract class OboeSampler implements Sampler {
    */
   protected updateSettings(settings: Settings): void {
     this.#settings = settings
-    for (const type of [
-      BucketType.DEFAULT,
-      BucketType.TRIGGER_RELAXED,
-      BucketType.TRIGGER_STRICT,
-    ]) {
-      const settings = this.#settings.buckets[type]
+    for (const [type, bucket] of Object.entries(this.#buckets)) {
+      const settings = this.#settings.buckets[type as BucketType]
       if (settings) {
-        this.#buckets[type].update(settings)
+        bucket.update(settings)
       }
     }
   }

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -1,0 +1,189 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  type DiagLogger,
+  type Span,
+  trace,
+  TraceFlags,
+} from "@opentelemetry/api"
+import {
+  type Sampler,
+  SamplingDecision,
+  type SamplingResult,
+} from "@opentelemetry/sdk-trace-base"
+
+import {
+  BucketType,
+  Flags,
+  type LocalSettings,
+  merge,
+  type Settings,
+} from "./settings.js"
+import { TokenBucket } from "./token-bucket.js"
+
+const TRACESTATE_REGEXP = /^[0-9a-f]{16}-[0-9a-f]{2}$/
+const BUCKET_INTERVAL = 1000
+
+export type SampleParams = Parameters<Sampler["shouldSample"]>
+
+export enum SpanType {
+  /** Root span without a parent */
+  ROOT,
+  /** Entry span with a remote parent */
+  ENTRY,
+  /** Local span with a local parent */
+  LOCAL,
+}
+
+/**
+ * This class implements all of the core sampling logic.
+ * It is meant to be extended by specific samplers that regularly call
+ * {@link updateSettings} and provide an implementation of {@link localSettings}.
+ *
+ * For instance, a classic sampler would retrieve the settings using gRPC,
+ * while a serverless sampler would retrieve them from the file on disk.
+ * By extending this class neither needs to reimplement shared sampling logic.
+ */
+export abstract class OboeSampler implements Sampler {
+  readonly #buckets: Record<BucketType, TokenBucket> = {
+    [BucketType.DEFAULT]: new TokenBucket({
+      interval: BUCKET_INTERVAL,
+    }),
+    [BucketType.TRIGGER_RELAXED]: new TokenBucket({
+      interval: BUCKET_INTERVAL,
+    }),
+    [BucketType.TRIGGER_STRICT]: new TokenBucket({
+      interval: BUCKET_INTERVAL,
+    }),
+  }
+  #settings: Settings | undefined = undefined
+
+  constructor(protected readonly logger: DiagLogger) {
+    for (const bucket of Object.values(this.#buckets)) {
+      bucket.start()
+      // unref the bucket so that it doesn't prevent the process from exiting
+      bucket.unref()
+    }
+  }
+
+  shouldSample(...params: SampleParams): SamplingResult {
+    const [context] = params
+    const parentSpan = trace.getSpan(context)
+    const type = spanType(parentSpan)
+    this.logger.debug(`span type is ${SpanType[type]}`)
+
+    // for local spans we always trust the parent
+    if (type === SpanType.LOCAL) {
+      if (parentSpan!.spanContext().traceFlags & TraceFlags.SAMPLED) {
+        return { decision: SamplingDecision.RECORD_AND_SAMPLED }
+      } else {
+        return { decision: SamplingDecision.NOT_RECORD }
+      }
+    }
+
+    const settings = this.#getSettings(...params)
+    if (!settings) {
+      this.logger.debug("settings unavailable; sampling disabled")
+      return { decision: SamplingDecision.NOT_RECORD }
+    }
+
+    const traceState = parentSpan?.spanContext().traceState?.get("sw")
+    if (traceState && TRACESTATE_REGEXP.test(traceState)) {
+      this.logger.debug("context is valid for parent based sampling")
+
+      if (settings.flags & Flags.SAMPLE_THROUGH_ALWAYS) {
+        this.logger.debug(
+          `${Flags[Flags.SAMPLE_THROUGH_ALWAYS]} is set; parent-based sampling`,
+        )
+
+        // this is guaranteed to be valid if the regexp matched
+        const flags = Number.parseInt(traceState.slice(-2), 16)
+        const sampled = flags & TraceFlags.SAMPLED
+
+        if (sampled) {
+          this.logger.debug(`parent is sampled; record and sample`)
+          return { decision: SamplingDecision.RECORD_AND_SAMPLED }
+        } else {
+          this.logger.debug(`parent is not sampled; record only`)
+          return { decision: SamplingDecision.RECORD }
+        }
+      } else {
+        this.logger.debug(
+          `${Flags[Flags.SAMPLE_THROUGH_ALWAYS]} is unset; sampling disabled`,
+        )
+
+        if (settings.flags & Flags.SAMPLE_START) {
+          this.logger.debug(`${Flags[Flags.SAMPLE_START]} is set; record`)
+          return { decision: SamplingDecision.RECORD }
+        } else {
+          this.logger.debug(
+            `${Flags[Flags.SAMPLE_START]} is unset; don't record`,
+          )
+          return { decision: SamplingDecision.NOT_RECORD }
+        }
+      }
+    }
+
+    throw new Error("TODO: Trigger Trace & Dice Roll")
+  }
+
+  /**
+   * Updates the current remote sampling settings. This should be called by
+   * the subclass whenever the remote settings are updated.
+   */
+  protected updateSettings(settings: Settings): void {
+    this.#settings = settings
+    for (const type of [
+      BucketType.DEFAULT,
+      BucketType.TRIGGER_RELAXED,
+      BucketType.TRIGGER_STRICT,
+    ]) {
+      const settings = this.#settings.buckets[type]
+      if (settings) {
+        this.#buckets[type].update(settings)
+      }
+    }
+  }
+
+  /**
+   * Retrieves the local settings for the given span information.
+   *
+   * @param params - Parameters passed to {@link Sampler.shouldSample}
+   */
+  abstract localSettings(...params: SampleParams): LocalSettings
+
+  /** See {@link Sampler.toString} */
+  abstract toString(): string
+
+  #getSettings(...params: SampleParams): Settings | undefined {
+    return (
+      this.#settings && merge(this.#settings, this.localSettings(...params))
+    )
+  }
+}
+
+export function spanType(parentSpan: Span | undefined): SpanType {
+  const parentSpanContext = parentSpan?.spanContext()
+
+  if (!parentSpanContext || !trace.isSpanContextValid(parentSpanContext)) {
+    return SpanType.ROOT
+  } else if (parentSpanContext.isRemote) {
+    return SpanType.ENTRY
+  } else {
+    return SpanType.LOCAL
+  }
+}

--- a/packages/sampling/src/settings.ts
+++ b/packages/sampling/src/settings.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export const SAMPLE_RATE_SCALE = 1_000_000
+
+export interface Settings {
+  sampleRate: number
+  flags: number
+  buckets: Partial<Record<BucketType, BucketSettings>>
+}
+
+export interface LocalSettings {
+  sampleRate?: number
+  tracingMode?: TracingMode
+  triggerMode: boolean
+}
+
+export enum Flags {
+  OK = 0x0,
+  INVALID = 0x1,
+  OVERRIDE = 0x2,
+  SAMPLE_START = 0x4,
+  SAMPLE_THROUGH_ALWAYS = 0x10,
+  TRIGGERED_TRACE = 0x20,
+}
+
+export enum TracingMode {
+  ALWAYS = Flags.SAMPLE_START | Flags.SAMPLE_THROUGH_ALWAYS,
+  NEVER = 0x0,
+}
+
+export enum BucketType {
+  DEFAULT = "",
+  TRIGGER_RELAXED = "TriggerRelaxed",
+  TRIGGER_STRICT = "TriggerStrict",
+}
+
+export interface BucketSettings {
+  capacity: number
+  rate: number
+}
+
+export function merge(remote: Settings, local: LocalSettings): Settings {
+  let sampleRate = local.sampleRate ?? remote.sampleRate
+  let flags = local.tracingMode ?? remote.flags
+
+  if (local.triggerMode) {
+    flags |= Flags.TRIGGERED_TRACE
+  } else {
+    flags &= ~Flags.TRIGGERED_TRACE
+  }
+
+  if (remote.flags & Flags.OVERRIDE) {
+    sampleRate = Math.min(sampleRate, remote.sampleRate)
+    flags &= remote.flags
+    // remember OVERRIDE (it could be unset above)
+    flags |= Flags.OVERRIDE
+  }
+
+  return { ...remote, sampleRate, flags }
+}

--- a/packages/sampling/src/token-bucket.ts
+++ b/packages/sampling/src/token-bucket.ts
@@ -129,6 +129,16 @@ export class TokenBucket {
     return this.#timer !== undefined
   }
 
+  /** https://nodejs.org/docs/latest/api/timers.html#timeoutref */
+  ref(): void {
+    this.#timer?.ref()
+  }
+
+  /** https://nodejs.org/docs/latest/api/timers.html#timeoutunref */
+  unref(): void {
+    this.#timer?.unref()
+  }
+
   #task() {
     this.#tokens += this.#rate
   }

--- a/packages/sampling/test/sampler.test.ts
+++ b/packages/sampling/test/sampler.test.ts
@@ -1,0 +1,264 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { randomBytes } from "node:crypto"
+
+import {
+  createTraceState,
+  diag,
+  ROOT_CONTEXT,
+  type Span,
+  SpanKind,
+  trace,
+  TraceFlags,
+} from "@opentelemetry/api"
+import { SamplingDecision } from "@opentelemetry/sdk-trace-base"
+import { describe, expect, it } from "@solarwinds-apm/test"
+
+import {
+  OboeSampler,
+  type SampleParams,
+  SpanType,
+  spanType,
+} from "../src/sampler.js"
+import { Flags, type LocalSettings, type Settings } from "../src/settings.js"
+
+interface MakeSpan {
+  name?: string
+  traceId?: string
+  id?: string
+
+  remote?: boolean
+  sampled?: boolean
+
+  sw?: boolean | "inverse"
+}
+const makeSpan = (options: MakeSpan = {}): Span => {
+  const object = {
+    name: options.name ?? "span",
+    traceId: options.traceId ?? randomBytes(16).toString("hex"),
+    id: options.id ?? randomBytes(8).toString("hex"),
+
+    remote: options.remote,
+    sampled: options.sampled ?? true,
+  }
+
+  const swFlags =
+    options.sw === "inverse"
+      ? object.sampled
+        ? "00"
+        : "01"
+      : object.sampled
+        ? "01"
+        : "00"
+
+  return {
+    spanContext: () => ({
+      traceId: object.traceId,
+      spanId: object.id,
+      isRemote: object.remote,
+      traceFlags: object.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
+      traceState: options.sw
+        ? createTraceState(`sw=${object.id}-${swFlags}`)
+        : undefined,
+    }),
+  } as Span
+}
+
+interface MakeSampleParams {
+  parent?: Span
+  name?: string
+  kind?: SpanKind
+}
+const makeSampleParams = (options: MakeSampleParams = {}): SampleParams => {
+  const object = {
+    parent: options.parent ?? makeSpan({ name: "parent span" }),
+    name: options.name ?? "child span",
+    kind: options.kind ?? SpanKind.INTERNAL,
+  }
+
+  return [
+    trace.setSpan(ROOT_CONTEXT, object.parent),
+    object.parent.spanContext().traceId,
+    object.name,
+    object.kind,
+    {},
+    [],
+  ]
+}
+
+class TestSampler extends OboeSampler {
+  #localSettings: LocalSettings
+
+  constructor(settings: Settings, localSettings: LocalSettings) {
+    super(diag)
+    this.#localSettings = localSettings
+    this.updateSettings(settings)
+  }
+
+  override localSettings(): LocalSettings {
+    return this.#localSettings
+  }
+
+  override toString(): string {
+    return "TestSampler"
+  }
+}
+
+describe("spanType", () => {
+  it("identifies no parent as ROOT", () => {
+    const type = spanType(undefined)
+    expect(type).to.equal(SpanType.ROOT)
+  })
+
+  it("identifies invalid parent as ROOT", () => {
+    const parent = makeSpan({ id: "woops" })
+
+    const type = spanType(parent)
+    expect(type).to.equal(SpanType.ROOT)
+  })
+
+  it("identifies remote parent as ENTRY", () => {
+    const parent = makeSpan({ remote: true })
+
+    const type = spanType(parent)
+    expect(type).to.equal(SpanType.ENTRY)
+  })
+
+  it("identifies local parent as LOCAL", () => {
+    const parent = makeSpan({ remote: false })
+
+    const type = spanType(parent)
+    expect(type).to.equal(SpanType.LOCAL)
+  })
+})
+
+describe("OboeSampler", () => {
+  describe("LOCAL span", () => {
+    it("respects parent sampled", () => {
+      const sampler = new TestSampler(
+        { sampleRate: 0, flags: 0x0, buckets: {} },
+        { triggerMode: false },
+      )
+
+      const parent = makeSpan({ remote: false, sampled: true })
+      const params = makeSampleParams({ parent })
+
+      const sample = sampler.shouldSample(...params)
+      expect(sample.decision).to.equal(SamplingDecision.RECORD_AND_SAMPLED)
+    })
+
+    it("respects parent not sampled", () => {
+      const sampler = new TestSampler(
+        { sampleRate: 0, flags: 0x0, buckets: {} },
+        { triggerMode: false },
+      )
+
+      const parent = makeSpan({ remote: false, sampled: false })
+      const params = makeSampleParams({ parent })
+
+      const sample = sampler.shouldSample(...params)
+      expect(sample.decision).to.equal(SamplingDecision.NOT_RECORD)
+    })
+  })
+
+  describe("ENTRY span with valid sw context", () => {
+    describe("SAMPLE_THROUGH_ALWAYS set", () => {
+      const sampler = new TestSampler(
+        { sampleRate: 0, flags: Flags.SAMPLE_THROUGH_ALWAYS, buckets: {} },
+        { triggerMode: false },
+      )
+
+      it("respects parent sampled", () => {
+        const parent = makeSpan({ remote: true, sw: true, sampled: true })
+        const params = makeSampleParams({ parent })
+
+        const sample = sampler.shouldSample(...params)
+        expect(sample.decision).to.equal(SamplingDecision.RECORD_AND_SAMPLED)
+      })
+
+      it("respects parent not sampled", () => {
+        const parent = makeSpan({ remote: true, sw: true, sampled: false })
+        const params = makeSampleParams({ parent })
+
+        const sample = sampler.shouldSample(...params)
+        expect(sample.decision).to.equal(SamplingDecision.RECORD)
+      })
+
+      it("respects sw sampled over w3c not sampled", () => {
+        const parent = makeSpan({ remote: true, sw: "inverse", sampled: false })
+        const params = makeSampleParams({ parent })
+
+        const sample = sampler.shouldSample(...params)
+        expect(sample.decision).to.equal(SamplingDecision.RECORD_AND_SAMPLED)
+      })
+
+      it("respects sw not sampled over w3c sampled", () => {
+        const parent = makeSpan({ remote: true, sw: "inverse", sampled: true })
+        const params = makeSampleParams({ parent })
+
+        const sample = sampler.shouldSample(...params)
+        expect(sample.decision).to.equal(SamplingDecision.RECORD)
+      })
+    })
+
+    describe("SAMPLE_THROUGH_ALWAYS unset", () => {
+      describe("SAMPLE_START set", () =>
+        it("records but does not sample", () => {
+          const sampler = new TestSampler(
+            {
+              sampleRate: 0,
+              flags: Flags.SAMPLE_START,
+              buckets: {},
+            },
+            { triggerMode: false },
+          )
+
+          const parent = makeSpan({
+            remote: true,
+            sw: true,
+            sampled: true,
+          })
+          const params = makeSampleParams({ parent })
+
+          const sample = sampler.shouldSample(...params)
+          expect(sample.decision).to.equal(SamplingDecision.RECORD)
+        }))
+
+      describe("SAMPLE_START unset", () =>
+        it("does not record or sample", () => {
+          const sampler = new TestSampler(
+            {
+              sampleRate: 0,
+              flags: 0x0,
+              buckets: {},
+            },
+            { triggerMode: false },
+          )
+
+          const parent = makeSpan({
+            remote: true,
+            sw: true,
+            sampled: true,
+          })
+          const params = makeSampleParams({ parent })
+
+          const sample = sampler.shouldSample(...params)
+          expect(sample.decision).to.equal(SamplingDecision.NOT_RECORD)
+        }))
+    })
+  })
+})

--- a/packages/sampling/test/settings.test.ts
+++ b/packages/sampling/test/settings.test.ts
@@ -1,0 +1,145 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it } from "@solarwinds-apm/test"
+
+import {
+  Flags,
+  type LocalSettings,
+  merge,
+  type Settings,
+  TracingMode,
+} from "../src/settings.js"
+
+describe("merge", () => {
+  describe("OVERRIDE is unset", () => {
+    it("respects lower sample rate, tracing mode NEVER & trigger mode disabled", () => {
+      const remote: Settings = {
+        sampleRate: 2,
+        flags:
+          Flags.SAMPLE_START |
+          Flags.SAMPLE_THROUGH_ALWAYS |
+          Flags.TRIGGERED_TRACE,
+        buckets: {},
+      }
+      const local: LocalSettings = {
+        sampleRate: 1,
+        tracingMode: TracingMode.NEVER,
+        triggerMode: false,
+      }
+
+      const merged = merge(remote, local)
+      expect(merged).to.include({
+        sampleRate: 1,
+        flags: 0x0,
+      })
+    })
+
+    it("respects higher sample rate, tracing mode ALWAYS & trigger mode enabled", () => {
+      const remote: Settings = {
+        sampleRate: 1,
+        flags: 0x0,
+        buckets: {},
+      }
+      const local: LocalSettings = {
+        sampleRate: 2,
+        tracingMode: TracingMode.ALWAYS,
+        triggerMode: true,
+      }
+
+      const merged = merge(remote, local)
+      expect(merged).to.include({
+        sampleRate: 2,
+        flags:
+          Flags.SAMPLE_START |
+          Flags.SAMPLE_THROUGH_ALWAYS |
+          Flags.TRIGGERED_TRACE,
+      })
+    })
+
+    it("defaults to remote value when local is unset", () => {
+      const remote: Settings = {
+        sampleRate: 1,
+        flags:
+          Flags.SAMPLE_START |
+          Flags.SAMPLE_THROUGH_ALWAYS |
+          Flags.TRIGGERED_TRACE,
+        buckets: {},
+      }
+      const local: LocalSettings = {
+        triggerMode: true,
+      }
+
+      const merged = merge(remote, local)
+      expect(merged).to.deep.equal(remote)
+    })
+  })
+
+  describe("OVERRIDE is set", () => {
+    it("respects lower sample rate, tracing mode NEVER & trigger mode disabled", () => {
+      const remote: Settings = {
+        sampleRate: 2,
+        flags:
+          Flags.OVERRIDE |
+          Flags.SAMPLE_START |
+          Flags.SAMPLE_THROUGH_ALWAYS |
+          Flags.TRIGGERED_TRACE,
+        buckets: {},
+      }
+      const local: LocalSettings = {
+        sampleRate: 1,
+        tracingMode: TracingMode.NEVER,
+        triggerMode: false,
+      }
+
+      const merged = merge(remote, local)
+      expect(merged).to.include({
+        sampleRate: 1,
+        flags: Flags.OVERRIDE,
+      })
+    })
+
+    it("does not respect higher sample rate, tracing mode ALWAYS & trigger mode enabled", () => {
+      const remote: Settings = {
+        sampleRate: 1,
+        flags: Flags.OVERRIDE,
+        buckets: {},
+      }
+      const local: LocalSettings = {
+        sampleRate: 2,
+        tracingMode: TracingMode.ALWAYS,
+        triggerMode: true,
+      }
+
+      const merged = merge(remote, local)
+      expect(merged).to.deep.equal(remote)
+    })
+
+    it("defaults to remote value when local is unset", () => {
+      const remote: Settings = {
+        sampleRate: 1,
+        flags: Flags.OVERRIDE,
+        buckets: {},
+      }
+      const local: LocalSettings = {
+        triggerMode: false,
+      }
+
+      const merged = merge(remote, local)
+      expect(merged).to.deep.equal(remote)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,6 +2082,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@solarwinds-apm/sampling@workspace:packages/sampling"
   dependencies:
+    "@opentelemetry/api": "npm:^1.3.0"
+    "@opentelemetry/sdk-trace-base": "npm:~1.23.0"
     "@solarwinds-apm/eslint-config": "workspace:^"
     "@solarwinds-apm/rollup-config": "workspace:^"
     "@solarwinds-apm/test": "workspace:^"
@@ -2090,6 +2092,11 @@ __metadata:
     prettier: "npm:^3.0.3"
     rollup: "npm:^4.3.0"
     typescript: "npm:~5.4.4"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This implements parent-based sampling logic both for local spans and remote ones with a valid `sw` context.

This also implements core logic for remote and local settings as a prerequisite. The logic for importing settings will live separately (similarly to the new liboboe implementation). At the moment there is also no support for layer names as the feature is not used in any of the OTel based libraries (as far as I know).