### PR TITLE
Trace options parsing

### DIFF
--- a/.yarn/versions/d5e3b4f0.yml
+++ b/.yarn/versions/d5e3b4f0.yml
@@ -1,0 +1,2 @@
+releases:
+  "@solarwinds-apm/sampling": minor

--- a/packages/sampling/src/dice.ts
+++ b/packages/sampling/src/dice.ts
@@ -25,7 +25,7 @@ export class Dice {
   #scale: number
 
   #r = 0
-  get #rate(): number {
+  get rate(): number {
     return this.#r
   }
   set #rate(n: number) {
@@ -39,10 +39,10 @@ export class Dice {
 
   update(settings: Partial<DiceSettings>) {
     this.#scale = settings.scale ?? this.#scale
-    this.#rate = settings.rate ?? this.#rate
+    this.#rate = settings.rate ?? this.rate
   }
 
   roll(): boolean {
-    return Math.random() * this.#scale < this.#rate
+    return Math.random() * this.#scale < this.rate
   }
 }

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -34,6 +34,7 @@ import {
   type Settings,
 } from "./settings.js"
 import { TokenBucket } from "./token-bucket.js"
+import { type RequestHeaders, type ResponseHeaders } from "./trace-options.js"
 
 const TRACESTATE_REGEXP = /^[0-9a-f]{16}-[0-9a-f]{2}$/
 const BUCKET_INTERVAL = 1000
@@ -160,7 +161,27 @@ export abstract class OboeSampler implements Sampler {
    *
    * @param params - Parameters passed to {@link Sampler.shouldSample}
    */
-  abstract localSettings(...params: SampleParams): LocalSettings
+  protected abstract localSettings(...params: SampleParams): LocalSettings
+
+  /**
+   * Retrieves the trace options request headers for the given span information.
+   *
+   * @param params - Parameters passed to {@link Sampler.shouldSample}
+   *
+   * @returns Headers set on the request that initiated the trace
+   */
+  protected abstract requestHeaders(...params: SampleParams): RequestHeaders
+
+  /**
+   * Sets the trace options response headers for the given span information
+   *
+   * @param headers - Headers to be set on the response to the request that initiated the trace
+   * @param params - Parameters passed to {@link Sampler.shouldSample}
+   */
+  protected abstract setResponseHeaders(
+    headers: ResponseHeaders,
+    ...params: SampleParams
+  ): void
 
   /** See {@link Sampler.toString} */
   abstract toString(): string

--- a/packages/sampling/src/token-bucket.ts
+++ b/packages/sampling/src/token-bucket.ts
@@ -31,7 +31,7 @@ export interface TokenBucketSettings {
 
 export class TokenBucket {
   #c = 0
-  get #capacity(): number {
+  get capacity(): number {
     return this.#c
   }
   set #capacity(n: number) {
@@ -39,7 +39,7 @@ export class TokenBucket {
   }
 
   #r = 0
-  get #rate(): number {
+  get rate(): number {
     return this.#r
   }
   set #rate(n: number) {
@@ -47,7 +47,7 @@ export class TokenBucket {
   }
 
   #i = MAX_INTERVAL
-  get #interval(): number {
+  get interval(): number {
     return this.#i
   }
   set #interval(n: number) {
@@ -59,7 +59,7 @@ export class TokenBucket {
     return this.#t
   }
   set #tokens(n: number) {
-    this.#t = Math.max(0, Math.min(this.#capacity, n))
+    this.#t = Math.max(0, Math.min(this.capacity, n))
   }
 
   #timer: NodeJS.Timer | undefined = undefined
@@ -69,12 +69,12 @@ export class TokenBucket {
     this.#rate = settings.rate ?? 0
     this.#interval = settings.interval ?? MAX_INTERVAL
 
-    this.#tokens = this.#capacity
+    this.#tokens = this.capacity
   }
 
   update(settings: TokenBucketSettings) {
     if (settings.capacity !== undefined) {
-      const difference = settings.capacity - this.#capacity
+      const difference = settings.capacity - this.capacity
       this.#capacity = settings.capacity
       this.#tokens += difference
     }
@@ -113,7 +113,7 @@ export class TokenBucket {
 
     this.#timer = setInterval(() => {
       this.#task()
-    }, this.#interval)
+    }, this.interval)
   }
 
   /** Stops replenishing the bucket */
@@ -140,6 +140,6 @@ export class TokenBucket {
   }
 
   #task() {
-    this.#tokens += this.#rate
+    this.#tokens += this.rate
   }
 }

--- a/packages/sampling/src/trace-options.ts
+++ b/packages/sampling/src/trace-options.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { diag, type DiagAPI } from "@opentelemetry/api"
+import { diag, type DiagLogger } from "@opentelemetry/api"
 
 const TRIGGER_TRACE_KEY = "trigger-trace"
 const TIMESTAMP_KEY = "ts"
@@ -42,7 +42,7 @@ export interface ResponseHeaders {
 
 export function parseTraceOptions(
   header: string,
-  logger: DiagAPI = diag,
+  logger: DiagLogger = diag,
 ): TraceOptions {
   const traceOptions: TraceOptions = {
     custom: {},

--- a/packages/sampling/src/trace-options.ts
+++ b/packages/sampling/src/trace-options.ts
@@ -1,0 +1,119 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { diag, type DiagAPI } from "@opentelemetry/api"
+
+const TRIGGER_TRACE_KEY = "trigger-trace"
+const TIMESTAMP_KEY = "ts"
+const SW_KEYS_KEY = "sw-keys"
+
+const CUSTOM_KEY_REGEX = /^custom-[^\s]+$/
+
+export interface TraceOptions {
+  triggerTrace?: true
+  timestamp?: number
+  swKeys?: string
+
+  custom: Record<string, string>
+  ignored: [string, string | undefined][]
+}
+
+export interface RequestHeaders {
+  traceOptions?: string
+  traceOptionsSignature?: string
+}
+
+export interface ResponseHeaders {
+  traceOptionsResponse?: string
+}
+
+export function parseTraceOptions(
+  header: string,
+  logger: DiagAPI = diag,
+): TraceOptions {
+  const traceOptions: TraceOptions = {
+    custom: {},
+    ignored: [],
+  }
+
+  const kvs = header
+    .split(";")
+    .map<[string, string | undefined]>((kv) => {
+      const [k, ...vs] = kv.split("=").map((s) => s.trim())
+      return [k!, vs.length > 0 ? vs.join("=") : undefined]
+    })
+    .filter(([k]) => k.length > 0)
+
+  for (const [k, v] of kvs) {
+    if (k === TRIGGER_TRACE_KEY) {
+      if (v !== undefined || traceOptions.triggerTrace !== undefined) {
+        logger.debug(
+          "invalid trace option for trigger trace, should not have a value and only be provided once",
+        )
+
+        traceOptions.ignored.push([k, v])
+        continue
+      }
+
+      traceOptions.triggerTrace = true
+    } else if (k === TIMESTAMP_KEY) {
+      if (v === undefined || traceOptions.timestamp !== undefined) {
+        logger.debug(
+          "invalid trace option for timestamp, should have a value and only be provided once",
+        )
+
+        traceOptions.ignored.push([k, v])
+        continue
+      }
+
+      const ts = Number.parseFloat(v)
+      if (!Number.isSafeInteger(ts)) {
+        logger.debug("invalid trace option for timestamp, should be an integer")
+
+        traceOptions.ignored.push([k, v])
+        continue
+      }
+
+      traceOptions.timestamp = ts
+    } else if (k === SW_KEYS_KEY) {
+      if (v === undefined || traceOptions.swKeys !== undefined) {
+        logger.debug(
+          "invalid trace option for sw keys, should have a value and only be provided once",
+        )
+
+        traceOptions.ignored.push([k, v])
+        continue
+      }
+
+      traceOptions.swKeys = v
+    } else if (CUSTOM_KEY_REGEX.test(k)) {
+      if (v === undefined || traceOptions.custom[k] !== undefined) {
+        logger.debug(
+          `invalid trace option for custom key ${k}, should have a value and only be provided once`,
+        )
+
+        traceOptions.ignored.push([k, v])
+        continue
+      }
+
+      traceOptions.custom[k] = v
+    } else {
+      traceOptions.ignored.push([k, v])
+    }
+  }
+
+  return traceOptions
+}

--- a/packages/sampling/test/trace-options.test.ts
+++ b/packages/sampling/test/trace-options.test.ts
@@ -1,0 +1,304 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it as test } from "@solarwinds-apm/test"
+
+import { parseTraceOptions } from "../src/trace-options.js"
+
+describe("parseTraceOptions", () => {
+  test("no key no value", () => {
+    const header = "="
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [],
+    })
+  })
+
+  test("orphan value", () => {
+    const header = "=value"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [],
+    })
+  })
+
+  test("valid trigger trace", () => {
+    const header = "trigger-trace"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      triggerTrace: true,
+      custom: {},
+      ignored: [],
+    })
+  })
+
+  test("trigger trace no value", () => {
+    const header = "trigger-trace=value"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [["trigger-trace", "value"]],
+    })
+  })
+
+  test("trigger trace duplicate", () => {
+    const header = "trigger-trace;trigger-trace"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      triggerTrace: true,
+      custom: {},
+      ignored: [["trigger-trace", undefined]],
+    })
+  })
+
+  test("timestamp no value", () => {
+    const header = "ts"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [["ts", undefined]],
+    })
+  })
+
+  test("timestamp duplicate", () => {
+    const header = "ts=1234;ts=5678"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      timestamp: 1234,
+      custom: {},
+      ignored: [["ts", "5678"]],
+    })
+  })
+
+  test("timestamp invalid", () => {
+    const header = "ts=value"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [["ts", "value"]],
+    })
+  })
+
+  test("timestamp float", () => {
+    const header = "ts=12.34"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [["ts", "12.34"]],
+    })
+  })
+
+  test("timestamp trim", () => {
+    const header = "ts = 1234567890 "
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      timestamp: 1234567890,
+      custom: {},
+      ignored: [],
+    })
+  })
+
+  test("sw-keys no value", () => {
+    const header = "sw-keys"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [["sw-keys", undefined]],
+    })
+  })
+
+  test("sw-keys duplicate", () => {
+    const header = "sw-keys=keys1;sw-keys=keys2"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      swKeys: "keys1",
+      custom: {},
+      ignored: [["sw-keys", "keys2"]],
+    })
+  })
+
+  test("sw-keys trim", () => {
+    const header = "sw-keys= name:value "
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      swKeys: "name:value",
+      custom: {},
+      ignored: [],
+    })
+  })
+
+  test("sw-keys ignore after semi", () => {
+    const header = "sw-keys=check-id:check-1013,website-id;booking-demo"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      swKeys: "check-id:check-1013,website-id",
+      custom: {},
+      ignored: [["booking-demo", undefined]],
+    })
+  })
+
+  test("custom keys trim", () => {
+    const header = "custom-key= value "
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {
+        "custom-key": "value",
+      },
+      ignored: [],
+    })
+  })
+
+  test("custom keys no value", () => {
+    const header = "custom-key"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [["custom-key", undefined]],
+    })
+  })
+
+  test("custom keys duplicate", () => {
+    const header = "custom-key=value1;custom-key=value2"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: { "custom-key": "value1" },
+      ignored: [["custom-key", "value2"]],
+    })
+  })
+
+  test("custom keys equals in value", () => {
+    const header = "custom-key=name=value"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {
+        "custom-key": "name=value",
+      },
+      ignored: [],
+    })
+  })
+
+  test("custom keys spaces in key", () => {
+    const header = "custom- key=value;custom-ke y=value"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [
+        ["custom- key", "value"],
+        ["custom-ke y", "value"],
+      ],
+    })
+  })
+
+  test("other ignored", () => {
+    const header = "key=value"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      custom: {},
+      ignored: [["key", "value"]],
+    })
+  })
+
+  test("trim everything", () => {
+    const header =
+      "trigger-trace ; custom-something=value; custom-OtherThing = other val ; sw-keys = 029734wr70:9wqj21,0d9j1 ; ts = 12345 ; foo = bar"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      triggerTrace: true,
+      swKeys: "029734wr70:9wqj21,0d9j1",
+      timestamp: 12345,
+      custom: {
+        "custom-something": "value",
+        "custom-OtherThing": "other val",
+      },
+      ignored: [["foo", "bar"]],
+    })
+  })
+
+  test("semi everywhere", () => {
+    const header =
+      ";foo=bar;;;custom-something=value_thing;;sw-keys=02973r70:1b2a3;;;;custom-key=val;ts=12345;;;;;;;trigger-trace;;;"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      triggerTrace: true,
+      swKeys: "02973r70:1b2a3",
+      timestamp: 12345,
+      custom: {
+        "custom-something": "value_thing",
+        "custom-key": "val",
+      },
+      ignored: [["foo", "bar"]],
+    })
+  })
+
+  test("single quotes", () => {
+    const header = "trigger-trace;custom-foo='bar;bar';custom-bar=foo"
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      triggerTrace: true,
+      custom: {
+        "custom-foo": "'bar",
+        "custom-bar": "foo",
+      },
+      ignored: [["bar'", undefined]],
+    })
+  })
+
+  test("missing values and semi", () => {
+    const header =
+      ";trigger-trace;custom-something=value_thing;sw-keys=02973r70:9wqj21,0d9j1;1;2;3;4;5;=custom-key=val?;="
+    const result = parseTraceOptions(header)
+
+    expect(result).to.loosely.deep.equal({
+      triggerTrace: true,
+      swKeys: "02973r70:9wqj21,0d9j1",
+      custom: {
+        "custom-something": "value_thing",
+      },
+      ignored: [
+        ["1", undefined],
+        ["2", undefined],
+        ["3", undefined],
+        ["4", undefined],
+        ["5", undefined],
+      ],
+    })
+  })
+})


### PR DESCRIPTION
This is mostly copied over from [the same logic in the trace options propagator](https://github.com/solarwinds/apm-js/blob/main/packages/sdk/src/trace-context-options-propagator.ts).