### PR TITLE
Trigger-tracing logic

### DIFF
--- a/.yarn/versions/cbdd5eaf.yml
+++ b/.yarn/versions/cbdd5eaf.yml
@@ -1,0 +1,2 @@
+releases:
+  "@solarwinds-apm/sampling": minor

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -158,6 +158,7 @@ export abstract class OboeSampler implements Sampler {
           s.traceOptions.timestamp,
         )
 
+        // if the request has an invalid signature we always short circuit
         if (s.traceOptions.response.auth !== Auth.OK) {
           this.logger.debug(
             "X-Trace-Options-Signature invalid; tracing disabled",
@@ -248,6 +249,8 @@ export abstract class OboeSampler implements Sampler {
       this.logger.debug("TRIGGERED_TRACE set; trigger tracing")
 
       let bucket: TokenBucket
+      // if there's an auth response present we know it's a valid signed request
+      // otherwise we would never have reached this code
       if (s.traceOptions!.response.auth) {
         this.logger.debug("signed request; using relaxed rate")
         bucket = this.#buckets[BucketType.TRIGGER_RELAXED]

--- a/packages/sampling/src/settings.ts
+++ b/packages/sampling/src/settings.ts
@@ -20,6 +20,7 @@ export interface Settings {
   sampleRate: number
   flags: number
   buckets: Partial<Record<BucketType, BucketSettings>>
+  signatureKey?: string
 }
 
 export interface LocalSettings {

--- a/packages/sampling/src/trace-options.ts
+++ b/packages/sampling/src/trace-options.ts
@@ -161,15 +161,15 @@ export function validateSignature(
   key: string | undefined,
   timestamp: number | undefined,
 ): Auth {
+  if (!key) {
+    return Auth.NO_SIGNATURE_KEY
+  }
+
   // unix seconds
   const now = Date.now() / 1000
   // timestamp must within 5 minutes
   if (!timestamp || Math.abs(now - timestamp) > 5 * 60) {
     return Auth.BAD_TIMESTAMP
-  }
-
-  if (!key) {
-    return Auth.NO_SIGNATURE_KEY
   }
 
   const hmac = createHmac("sha1", key)

--- a/packages/sampling/src/trace-options.ts
+++ b/packages/sampling/src/trace-options.ts
@@ -176,9 +176,9 @@ export function validateSignature(
   const hmac = createHmac("sha1", key)
   const digest = hmac.update(header).digest()
 
-  if (signature !== digest.toString("hex")) {
+  if (signature === digest.toString("hex")) {
+    return Auth.OK
+  } else {
     return Auth.BAD_SIGNATURE
   }
-
-  return Auth.OK
 }

--- a/packages/sampling/src/trace-options.ts
+++ b/packages/sampling/src/trace-options.ts
@@ -60,6 +60,7 @@ export enum TriggerTrace {
   IGNORED = "ignored",
   TRACING_DISABLED = "tracing-disabled",
   TRIGGER_TRACING_DISABLED = "trigger-tracing-disabled",
+  RATE_EXCEEDED = "rate-exceeded",
 }
 
 export function parseTraceOptions(

--- a/packages/sampling/test/sampler.test.ts
+++ b/packages/sampling/test/sampler.test.ts
@@ -48,6 +48,10 @@ interface MakeSpan {
   remote?: boolean
   sampled?: boolean
 
+  /**
+   * Whether to generate a sw tracestate field.
+   * "inverse" will generate a field that contradicts the W3C trace flags.
+   */
   sw?: boolean | "inverse"
 }
 const makeSpan = (options: MakeSpan = {}): Span => {


### PR DESCRIPTION
This implements the core trigger-tracing logic and tests. It also moves the parent-based code around a bit the the logic remains the same. After this the only remaining piece is the dice roll logic.