### PR TITLE
Handle TTL

### DIFF
--- a/.yarn/versions/19fe8cd4.yml
+++ b/.yarn/versions/19fe8cd4.yml
@@ -1,6 +1,2 @@
 releases:
   "@solarwinds-apm/sampling": minor
-
-undecided:
-  - "@solarwinds-apm/proto"
-  - "@solarwinds-apm/sdk"

--- a/.yarn/versions/19fe8cd4.yml
+++ b/.yarn/versions/19fe8cd4.yml
@@ -1,0 +1,6 @@
+releases:
+  "@solarwinds-apm/sampling": minor
+
+undecided:
+  - "@solarwinds-apm/proto"
+  - "@solarwinds-apm/sdk"

--- a/packages/sampling/src/index.ts
+++ b/packages/sampling/src/index.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { OboeSampler } from "./sampler.js"
+export {
+  BucketSettings,
+  BucketType,
+  Flags,
+  LocalSettings,
+  Settings,
+  TracingMode,
+} from "./settings.js"
+export { RequestHeaders, ResponseHeaders } from "./trace-options.js"

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -103,6 +103,7 @@ export abstract class OboeSampler implements Sampler {
     }),
   }
   #settings: Settings | undefined = undefined
+  #updated: number = Date.now()
 
   constructor(protected readonly logger: DiagLogger) {
     for (const bucket of Object.values(this.#buckets)) {
@@ -359,7 +360,11 @@ export abstract class OboeSampler implements Sampler {
    * the subclass whenever the remote settings are updated.
    */
   protected updateSettings(settings: Settings): void {
+    this.logger.debug("settings updated", settings)
+
     this.#settings = settings
+    this.#updated = Date.now()
+
     for (const [type, bucket] of Object.entries(this.#buckets)) {
       const settings = this.#settings.buckets[type as BucketType]
       if (settings) {
@@ -411,9 +416,17 @@ export abstract class OboeSampler implements Sampler {
   abstract toString(): string
 
   #getSettings(...params: SampleParams): Settings | undefined {
-    return (
-      this.#settings && merge(this.#settings, this.localSettings(...params))
-    )
+    if (!this.#settings) {
+      return
+    }
+
+    const expiry = this.#updated + this.#settings.ttl * 1000
+    if (Date.now() > expiry) {
+      this.logger.debug("settings expired")
+      return
+    }
+
+    return merge(this.#settings, this.localSettings(...params))
   }
 }
 

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -422,7 +422,8 @@ export abstract class OboeSampler implements Sampler {
 
     const expiry = this.#updated + this.#settings.ttl * 1000
     if (Date.now() > expiry) {
-      this.logger.debug("settings expired")
+      this.logger.debug("settings expired, removing")
+      this.#settings = undefined
       return
     }
 

--- a/packages/sampling/src/settings.ts
+++ b/packages/sampling/src/settings.ts
@@ -18,7 +18,8 @@ export interface Settings {
   sampleRate: number
   flags: number
   buckets: Partial<Record<BucketType, BucketSettings>>
-  signatureKey?: string
+  signatureKey?: Uint8Array
+  ttl: number
 }
 
 export interface LocalSettings {

--- a/packages/sampling/src/trace-options.ts
+++ b/packages/sampling/src/trace-options.ts
@@ -160,7 +160,7 @@ export function stringifyTraceOptionsResponse(
 export function validateSignature(
   header: string,
   signature: string,
-  key: string | undefined,
+  key: Uint8Array | undefined,
   timestamp: number | undefined,
 ): Auth {
   if (!key) {


### PR DESCRIPTION
Invalidates settings past their TTL. Also use Uint8Array instead of string to store secret key, because it's returned as binary by the collector and Uint8Array can represent any string but not the opposite.