### PR TITLE
Better utilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,3 +66,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.yarn/versions/19fe8cd4.yml
+++ b/.yarn/versions/19fe8cd4.yml
@@ -1,2 +1,11 @@
 releases:
+  "@solarwinds-apm/proto": patch
   "@solarwinds-apm/sampling": minor
+  "@solarwinds-apm/test": minor
+  solarwinds-apm: minor
+
+declined:
+  - "@solarwinds-apm/bindings"
+  - "@solarwinds-apm/compat"
+  - "@solarwinds-apm/dependencies"
+  - "@solarwinds-apm/sdk"

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -46,8 +46,6 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/sdk-trace-base": "~1.23.0",
-    "@opentelemetry/sdk-trace-node": "~1.23.0",
     "@opentelemetry/semantic-conventions": "~1.23.0",
     "@solarwinds-apm/eslint-config": "workspace:^",
     "@solarwinds-apm/rollup-config": "workspace:^",

--- a/packages/proto/build.js
+++ b/packages/proto/build.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { mkdir } from "node:fs/promises"
+import { mkdir, writeFile } from "node:fs/promises"
 import { promisify } from "node:util"
 
 import { main as pbjsMain } from "protobufjs-cli/pbjs.js"
@@ -34,6 +34,9 @@ const targets = {
 
 for (const [target, options] of Object.entries(targets)) {
   await mkdir(`dist/${target}`, { recursive: true })
+
+  const type = target === "es" ? "module" : "commonjs"
+  await writeFile(`dist/${target}/package.json`, JSON.stringify({ type }))
 
   await pbjs([
     "-t",

--- a/packages/sampling/src/index.ts
+++ b/packages/sampling/src/index.ts
@@ -14,13 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { OboeSampler } from "./sampler.js"
-export {
-  BucketSettings,
-  BucketType,
-  Flags,
-  LocalSettings,
-  Settings,
-  TracingMode,
-} from "./settings.js"
-export { RequestHeaders, ResponseHeaders } from "./trace-options.js"
+export * from "./sampler.js"
+export * from "./settings.js"
+export * from "./trace-options.js"

--- a/packages/sampling/test/dice.test.ts
+++ b/packages/sampling/test/dice.test.ts
@@ -34,7 +34,7 @@ describe("Dice", () => {
     // statistically we should always be between 40%-60% over 1000 rolls
     // otherwise something is very wrong
     expect(Math.abs(trues - falses)).to.be.below(100)
-  })
+  }).retries(2)
 
   it("defaults to zero and never succeeds", () => {
     const dice = new Dice({ scale: 100 })

--- a/packages/sdk/test/context.test.ts
+++ b/packages/sdk/test/context.test.ts
@@ -21,8 +21,7 @@ import {
   trace,
   TraceFlags,
 } from "@opentelemetry/api"
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
-import { describe, expect, it } from "@solarwinds-apm/test"
+import { describe, expect, it, otel } from "@solarwinds-apm/test"
 
 import { cache } from "../src/cache"
 import {
@@ -115,12 +114,12 @@ describe("setTransactionName", () => {
       .to.be.false
   })
 
-  it("returns true and sets the transaction name of the root span if there is a cache entry", () => {
-    const txname = "foo"
+  it("returns true and sets the transaction name of the root span if there is a cache entry", async () => {
+    await otel.reset({
+      trace: { processors: [new SwParentInfoSpanProcessor()] },
+    })
 
-    const provider = new NodeTracerProvider()
-    provider.addSpanProcessor(new SwParentInfoSpanProcessor())
-    provider.register()
+    const txname = "foo"
 
     const tracer = trace.getTracer("test")
 

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -58,6 +58,7 @@
     "test": "swtest -p test/tsconfig.json -c src"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.10.6",
     "@opentelemetry/core": "~1.23.0",
     "@opentelemetry/instrumentation": "~0.50.0",
     "@opentelemetry/resources": "~1.23.0",
@@ -68,6 +69,8 @@
     "@solarwinds-apm/bindings": "workspace:^",
     "@solarwinds-apm/instrumentations": "workspace:^",
     "@solarwinds-apm/module": "workspace:^",
+    "@solarwinds-apm/proto": "workspace:^",
+    "@solarwinds-apm/sampling": "workspace:^",
     "@solarwinds-apm/sdk": "workspace:^",
     "semver": "^7.5.4",
     "zod": "^3.22.4"

--- a/packages/solarwinds-apm/src/processing/parent.ts
+++ b/packages/solarwinds-apm/src/processing/parent.ts
@@ -24,11 +24,13 @@ import { spanStorage } from "../storage.js"
 
 const PARENT_STORAGE = spanStorage<Span | false>("solarwinds-apm parent span")
 
+/** Returns true if this span has no parent or its parent is remote */
 export function isRootOrEntry(span: Span): boolean {
   const parentSpan = PARENT_STORAGE.get(span)
   return parentSpan === false || parentSpan?.spanContext().isRemote === true
 }
 
+/** Traverses the span hierarchy until it finds the root or entry */
 export function getRootOrEntry(span: Span): Span | undefined {
   let parentSpan = PARENT_STORAGE.get(span)
 
@@ -44,6 +46,7 @@ export function getRootOrEntry(span: Span): Span | undefined {
   return undefined
 }
 
+/** Processor that stores span parents */
 export class ParentSpanProcessor
   extends NoopSpanProcessor
   implements SpanProcessor

--- a/packages/solarwinds-apm/src/processing/parent.ts
+++ b/packages/solarwinds-apm/src/processing/parent.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { type Context, type Span, trace } from "@opentelemetry/api"
+import {
+  NoopSpanProcessor,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base"
+
+import { spanStorage } from "../storage.js"
+
+const PARENT_STORAGE = spanStorage<Span | false>("solarwinds-apm parent span")
+
+export function isRootOrEntry(span: Span): boolean {
+  const parentSpan = PARENT_STORAGE.get(span)
+  return parentSpan === false || parentSpan?.spanContext().isRemote === true
+}
+
+export function getRootOrEntry(span: Span): Span | undefined {
+  let parentSpan = PARENT_STORAGE.get(span)
+
+  while (parentSpan !== undefined) {
+    if (parentSpan === false || parentSpan.spanContext().isRemote) {
+      return span
+    }
+
+    span = parentSpan
+    parentSpan = PARENT_STORAGE.get(span)
+  }
+
+  return undefined
+}
+
+export class ParentSpanProcessor
+  extends NoopSpanProcessor
+  implements SpanProcessor
+{
+  override onStart(span: Span, parentContext: Context): void {
+    const parentSpan = trace.getSpan(parentContext)
+    PARENT_STORAGE.set(span, parentSpan ?? false)
+  }
+}

--- a/packages/solarwinds-apm/src/processing/parent.ts
+++ b/packages/solarwinds-apm/src/processing/parent.ts
@@ -22,6 +22,7 @@ import {
 
 import { spanStorage } from "../storage.js"
 
+/** Parent storage where false means no parent */
 const PARENT_STORAGE = spanStorage<Span | false>("solarwinds-apm parent span")
 
 /** Returns true if this span has no parent or its parent is remote */

--- a/packages/solarwinds-apm/src/processing/parent.ts
+++ b/packages/solarwinds-apm/src/processing/parent.ts
@@ -31,7 +31,7 @@ export function isRootOrEntry(span: Span): boolean {
   return parentSpan === false || parentSpan?.spanContext().isRemote === true
 }
 
-/** Traverses the span hierarchy until it finds the root or entry */
+/** Traverses the span hierarchy until the root or entry is found */
 export function getRootOrEntry(span: Span): Span | undefined {
   let parentSpan = PARENT_STORAGE.get(span)
 

--- a/packages/solarwinds-apm/src/propagation/headers.ts
+++ b/packages/solarwinds-apm/src/propagation/headers.ts
@@ -1,0 +1,107 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  type Context,
+  type TextMapGetter,
+  type TextMapPropagator,
+  type TextMapSetter,
+} from "@opentelemetry/api"
+import type * as sampling from "@solarwinds-apm/sampling"
+
+import { contextStorage } from "../storage.js"
+import { firstIfArray, joinIfArray } from "../util.js"
+
+/** SolarWinds headers */
+export interface Headers {
+  /** Headers to be extracted from incoming requests */
+  request: sampling.RequestHeaders
+  /** Headers to be injected into outgoing responses */
+  response: sampling.ResponseHeaders
+}
+
+export type RequestHeader = keyof Headers["request"]
+export type ResponseHeader = keyof Headers["response"]
+export type Header = RequestHeader | ResponseHeader
+
+/** Storage for headers inside the OTel Context */
+export const HEADERS_STORAGE = contextStorage<Headers>("solarwinds-apm headers")
+
+const X_TRACE_OPTIONS = "X-Trace-Options" satisfies Header
+const X_TRACE_OPTIONS_RESPONSE = "X-Trace-Options-Response" satisfies Header
+const X_TRACE_OPTIONS_SIGNATURE = "X-Trace-Options-Signature" satisfies Header
+
+/**
+ * Propagator that extracts SolarWinds request headers
+ */
+export class RequestHeadersPropagator implements TextMapPropagator<unknown> {
+  extract(
+    context: Context,
+    carrier: unknown,
+    getter: TextMapGetter<unknown>,
+  ): Context {
+    return HEADERS_STORAGE.set(context, {
+      request: {
+        [X_TRACE_OPTIONS]: joinIfArray(
+          getter.get(carrier, X_TRACE_OPTIONS.toLowerCase()),
+          ";",
+        ),
+        [X_TRACE_OPTIONS_SIGNATURE]: firstIfArray(
+          getter.get(carrier, X_TRACE_OPTIONS_SIGNATURE.toLowerCase()),
+        ),
+      },
+      response: {},
+    })
+  }
+
+  inject(): void {
+    return
+  }
+
+  fields(): RequestHeader[] {
+    return [X_TRACE_OPTIONS, X_TRACE_OPTIONS_SIGNATURE]
+  }
+}
+
+/**
+ * Propagator that injects SolarWinds response headers
+ *
+ * This propagator SHOULD NOT be registered with the tracer provider
+ * since it is meant for response and not request.
+ * Currently it is registered in the HTTP instrumentation response hook
+ * until an official response propagation API is added.
+ */
+export class ResponseHeadersPropagator implements TextMapPropagator<unknown> {
+  inject(
+    context: Context,
+    carrier: unknown,
+    setter: TextMapSetter<unknown>,
+  ): void {
+    const headers = HEADERS_STORAGE.get(context)?.response ?? {}
+    for (const [name, value] of Object.entries(headers)) {
+      if (!value) continue
+      setter.set(carrier, name, value as string)
+    }
+  }
+
+  fields(): ResponseHeader[] {
+    return [X_TRACE_OPTIONS_RESPONSE]
+  }
+
+  extract(context: Context): Context {
+    return context
+  }
+}

--- a/packages/solarwinds-apm/src/storage.ts
+++ b/packages/solarwinds-apm/src/storage.ts
@@ -1,0 +1,143 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  type Context,
+  createContextKey,
+  diag,
+  type Span,
+} from "@opentelemetry/api"
+import * as sdk from "@opentelemetry/sdk-trace-base"
+
+/**
+ * Creates a global value shared between ESM and CommonJS contexts
+ *
+ * @param id - Descriptive unique ID for the global
+ * @param init - Initializer for the global if it needs to be
+ *
+ * @returns Shared global
+ */
+export function global<const T>(id: string, init: () => T): T {
+  const key = Symbol.for(`solarwinds-apm global storage / ${id}`)
+  let storage = Reflect.get(globalThis, key) as T | undefined
+
+  if (!storage) {
+    storage = init()
+    Reflect.defineProperty(globalThis, key, {
+      value: storage,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    })
+  }
+
+  return storage
+}
+
+/** Typed wrapper around the OTel {@link Context} API for a specific key */
+export interface ContextStorage<T> {
+  /**
+   * Gets the value for the key
+   *
+   * Note that while the context object itself is immutable,
+   * reference types stored in it are not. This means it is possible
+   * to modify the return value of this function in-place if it is
+   * a reference type.
+   */
+  get(context: Context): T | undefined
+  /**
+   * Sets the value for the key
+   *
+   * Note that the context object is immutable and this function
+   * returns an updated context without modifying the given one in-place.
+   * in-place
+   */
+  set(context: Context, value: T): Context
+  /**
+   * Deletes the value for the key
+   *
+   * Note that the context object is immutable and this function
+   * returns an updated context without modifying the given one in-place.
+   */
+  delete(context: Context): Context
+}
+
+/**
+ * Typed OTel {@link Span} attached storage API for a specific key
+ *
+ * This makes it possible to attach arbitrary data to OTel spans
+ * without altering the span object.
+ *
+ * The stored value will be accessible throughout the entire
+ * lifecycle of the span from the moment it is set until the span
+ * finishes being exported.
+ *
+ * Unlike the previous implementation which used the span ID as a key
+ * and needed to be carefully cleared at the right times to avoid leaking
+ * memory, this uses a WeakMap with the span object itself as a key
+ * which ensures the stored values are kept exactly as long as they need
+ * to be accessed.
+ */
+export interface SpanStorage<T> {
+  get(span: Span | sdk.Span | sdk.ReadableSpan): T | undefined
+  set(span: Span | sdk.Span | sdk.ReadableSpan, value: T): boolean
+}
+
+const GLOBAL_SPAN_STORAGE = global(
+  "solarwinds-apm span storage",
+  () => new WeakMap<sdk.Span, Record<symbol, unknown>>(),
+)
+
+function withSdkSpan<T, const U>(
+  span: Span | sdk.Span | sdk.ReadableSpan,
+  fallback: U,
+  f: (span: sdk.Span) => T,
+): T | U {
+  if (span instanceof sdk.Span) {
+    return f(span)
+  } else {
+    diag.debug("span storage passed an invalid key", span)
+    return fallback
+  }
+}
+
+/** Creates a new {@link ContextStorage} for the given ID */
+export function contextStorage<T>(id: string): ContextStorage<T> {
+  const key = createContextKey(id)
+  return {
+    get: (ctx) => ctx.getValue(key) as T | undefined,
+    set: (ctx, val) => ctx.setValue(key, val),
+    delete: (ctx) => ctx.deleteValue(key),
+  }
+}
+
+/** Creates a new {@link SpanStorage} for the given ID */
+export function spanStorage<T>(id: string): SpanStorage<T> {
+  const key = Symbol.for(id)
+  return {
+    get: (span) =>
+      withSdkSpan(span, undefined, (span) => {
+        return GLOBAL_SPAN_STORAGE.get(span)?.[key] as T | undefined
+      }),
+    set: (span, val) =>
+      withSdkSpan(span, false, (span) => {
+        const storage = GLOBAL_SPAN_STORAGE.get(span) ?? {}
+        storage[key] = val
+        GLOBAL_SPAN_STORAGE.set(span, storage)
+        return true
+      }),
+  }
+}

--- a/packages/solarwinds-apm/src/storage.ts
+++ b/packages/solarwinds-apm/src/storage.ts
@@ -131,6 +131,7 @@ export function contextStorage<T>(id: string): ContextStorage<T> {
 /** Creates a new {@link SpanStorage} for the given ID */
 export function spanStorage<T>(id: string): SpanStorage<T> {
   const key = Symbol.for(id)
+
   return {
     get: (span) =>
       withSdkSpan(span, undefined, (span) => {

--- a/packages/solarwinds-apm/src/util.ts
+++ b/packages/solarwinds-apm/src/util.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Returns the first element if the value is an array
+ * or the value as-is otherwise
+ */
+export function firstIfArray<T>(value: T | T[] | undefined): T | undefined {
+  if (Array.isArray(value)) {
+    return value[0]
+  } else {
+    return value
+  }
+}
+
+/**
+ * Returns the result of {@link Array.join} if the value is an array
+ * or the value as-is otherwise
+ *
+ * @param separator - Separator used between elements
+ */
+export function joinIfArray(
+  value: string | string[] | undefined,
+  separator: string,
+): string | undefined {
+  if (Array.isArray(value)) {
+    if (value.length > 0) {
+      return value.join(separator)
+    } else {
+      return undefined
+    }
+  } else {
+    return value
+  }
+}

--- a/packages/solarwinds-apm/test/processing.ts/parent.test.ts
+++ b/packages/solarwinds-apm/test/processing.ts/parent.test.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { trace } from "@opentelemetry/api"
+import { describe, expect, it, otel } from "@solarwinds-apm/test"
+
+import {
+  getRootOrEntry,
+  isRootOrEntry,
+  ParentSpanProcessor,
+} from "../../src/processing/parent.js"
+
+await otel.reset({ trace: { processors: [new ParentSpanProcessor()] } })
+
+const tracer = trace.getTracer("test")
+
+describe("ParentSpanProcessor", () => {
+  it("registers parent span information", () => {
+    tracer.startActiveSpan("parent", (parentSpan) => {
+      expect(isRootOrEntry(parentSpan)).to.be.true
+      expect(getRootOrEntry(parentSpan)).to.equal(parentSpan)
+
+      tracer.startActiveSpan("child", (childSpan) => {
+        expect(isRootOrEntry(childSpan)).to.be.false
+        expect(getRootOrEntry(childSpan)).to.equal(parentSpan)
+
+        childSpan.end()
+      })
+
+      parentSpan.end()
+    })
+  })
+})

--- a/packages/solarwinds-apm/test/propagation/headers.test.ts
+++ b/packages/solarwinds-apm/test/propagation/headers.test.ts
@@ -1,0 +1,96 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  defaultTextMapGetter,
+  defaultTextMapSetter,
+  ROOT_CONTEXT,
+} from "@opentelemetry/api"
+import { describe, expect, it } from "@solarwinds-apm/test"
+
+import {
+  HEADERS_STORAGE,
+  RequestHeadersPropagator,
+  ResponseHeadersPropagator,
+} from "../../src/propagation/headers.js"
+
+describe("RequestHeadersPropagator", () => {
+  const propagator = new RequestHeadersPropagator()
+
+  it("extracts empty headers when not present", () => {
+    const context = propagator.extract(ROOT_CONTEXT, {}, defaultTextMapGetter)
+    expect(HEADERS_STORAGE.get(context)?.request).to.loosely.deep.equal({})
+  })
+
+  it("extracts single headers", () => {
+    const headers = {
+      "x-trace-options": "options",
+      "x-trace-options-signature": "options-signature",
+    }
+    const context = propagator.extract(
+      ROOT_CONTEXT,
+      headers,
+      defaultTextMapGetter,
+    )
+    expect(HEADERS_STORAGE.get(context)?.request).to.loosely.deep.equal({
+      "X-Trace-Options": "options",
+      "X-Trace-Options-Signature": "options-signature",
+    })
+  })
+
+  it("extracts multi headers", () => {
+    const headers = {
+      "x-trace-options": ["foo", "bar"],
+      "x-trace-options-signature": ["good", "bad"],
+    }
+    const context = propagator.extract(
+      ROOT_CONTEXT,
+      headers,
+      defaultTextMapGetter,
+    )
+    expect(HEADERS_STORAGE.get(context)?.request).to.loosely.deep.equal({
+      "X-Trace-Options": "foo;bar",
+      "X-Trace-Options-Signature": "good",
+    })
+  })
+
+  it("lists proper fields", () => {
+    expect(propagator.fields()).to.have.members([
+      "X-Trace-Options",
+      "X-Trace-Options-Signature",
+    ])
+  })
+})
+
+describe("ResponseHeadersPropagator", () => {
+  const propagator = new ResponseHeadersPropagator()
+
+  it("injects headers", () => {
+    const headers = {}
+    const context = HEADERS_STORAGE.set(ROOT_CONTEXT, {
+      request: {},
+      response: { "X-Trace-Options-Response": "response" },
+    })
+    propagator.inject(context, headers, defaultTextMapSetter)
+    expect(headers).to.loosely.deep.equal({
+      "X-Trace-Options-Response": "response",
+    })
+  })
+
+  it("lists proper fields", () => {
+    expect(propagator.fields()).to.have.members(["X-Trace-Options-Response"])
+  })
+})

--- a/packages/solarwinds-apm/test/storage.test.ts
+++ b/packages/solarwinds-apm/test/storage.test.ts
@@ -58,6 +58,9 @@ describe("SpanStorage", () => {
     })
 
     expect(storage.get(span)).to.equal("value")
+
+    storage.delete(span)
+    expect(storage.get(span)).to.be.undefined
   })
 
   it("ignores invalid spans", () => {

--- a/packages/solarwinds-apm/test/storage.test.ts
+++ b/packages/solarwinds-apm/test/storage.test.ts
@@ -1,0 +1,68 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ROOT_CONTEXT, type Span, trace } from "@opentelemetry/api"
+import { describe, expect, it } from "@solarwinds-apm/test"
+
+import { contextStorage, global, spanStorage } from "../src/storage.js"
+
+const tracer = trace.getTracer("test")
+
+describe("global", () => {
+  it("works", () => {
+    const value = global("test", () => "value")
+    expect(value).to.equal("value")
+  })
+
+  it("returns existing", () => {
+    const value = global("test", () => "not value")
+    expect(value).to.equal("value")
+  })
+})
+
+describe("ContextStorage", () => {
+  const storage = contextStorage<string>("test")
+
+  it("works", () => {
+    const context = storage.set(ROOT_CONTEXT, "value")
+    expect(storage.get(context)).to.equal("value")
+  })
+
+  it("returns undefined if unset", () => {
+    expect(storage.get(ROOT_CONTEXT)).to.be.undefined
+  })
+})
+
+describe("SpanStorage", () => {
+  const storage = spanStorage<string>("test")
+
+  it("works", () => {
+    const span = tracer.startActiveSpan("test", (span) => {
+      expect(storage.set(span, "value")).to.be.true
+
+      span.end()
+      return span
+    })
+
+    expect(storage.get(span)).to.equal("value")
+  })
+
+  it("ignores invalid spans", () => {
+    const span = {} as Span
+    expect(storage.set(span, "value")).to.be.false
+    expect(storage.get(span)).to.be.undefined
+  })
+})

--- a/packages/solarwinds-apm/test/util.test.ts
+++ b/packages/solarwinds-apm/test/util.test.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it } from "@solarwinds-apm/test"
+
+import { firstIfArray, joinIfArray } from "../src/util.js"
+
+describe("firstIfArray", () => {
+  it("returns undefined if undefined", () => {
+    expect(firstIfArray<string>(undefined)).to.be.undefined
+  })
+
+  it("returns value if not array", () => {
+    expect(firstIfArray("value")).to.equal("value")
+  })
+
+  it("returns undefined if empty array", () => {
+    expect(firstIfArray<number>([])).to.be.undefined
+  })
+
+  it("returns first element if array", () => {
+    expect(firstIfArray([1, 2])).to.equal(1)
+  })
+})
+
+describe("joinIfArray", () => {
+  it("returns undefined if undefined", () => {
+    expect(joinIfArray(undefined, ";")).to.be.undefined
+  })
+
+  it("returns value if not array", () => {
+    expect(joinIfArray("value", ";")).to.equal("value")
+  })
+
+  it("returns undefined if empty array", () => {
+    expect(joinIfArray([], ";")).to.be.undefined
+  })
+
+  it("returns joined if array", () => {
+    expect(joinIfArray(["foo", "bar"], ";")).to.equal("foo;bar")
+  })
+})

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -59,6 +59,10 @@
     "ts-node": "^11.0.0-beta.1"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/sdk-metrics": "~1.23.0",
+    "@opentelemetry/sdk-trace-base": "~1.23.0",
+    "@opentelemetry/sdk-trace-node": "~1.23.0",
     "@solarwinds-apm/eslint-config": "workspace:^",
     "@solarwinds-apm/rollup-config": "workspace:^",
     "eslint": "^8.50.0",

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -16,6 +16,24 @@ limitations under the License.
 
 import "./plugin.js"
 
+import { metrics, trace } from "@opentelemetry/api"
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  type MeterProviderOptions,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics"
+import {
+  InMemorySpanExporter,
+  type SDKRegistrationConfig,
+  SimpleSpanProcessor,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base"
+import {
+  type NodeTracerConfig,
+  NodeTracerProvider,
+} from "@opentelemetry/sdk-trace-node"
 import * as chai from "chai"
 import chaiAsPromised from "chai-as-promised"
 
@@ -23,3 +41,72 @@ chai.use(chaiAsPromised)
 
 export { expect } from "chai"
 export { after, afterEach, before, beforeEach, describe, it } from "mocha"
+
+let spanExporter: InMemorySpanExporter
+let spanProcessor: SimpleSpanProcessor
+let tracerProvider: NodeTracerProvider
+
+let metricExporter: InMemoryMetricExporter
+let metricReader: PeriodicExportingMetricReader
+let meterProvider: MeterProvider
+
+export interface OtelConfig {
+  trace?: NodeTracerConfig &
+    SDKRegistrationConfig & { processors?: SpanProcessor[] }
+  metrics?: MeterProviderOptions
+}
+
+function initOtel(config: OtelConfig) {
+  trace.disable()
+  metrics.disable()
+
+  spanExporter = new InMemorySpanExporter()
+  spanProcessor = new SimpleSpanProcessor(spanExporter)
+
+  tracerProvider = new NodeTracerProvider(config.trace)
+  for (const processor of [
+    ...(config.trace?.processors ?? []),
+    spanProcessor,
+  ]) {
+    tracerProvider.addSpanProcessor(processor)
+  }
+  tracerProvider.register(config.trace)
+
+  metricExporter = new InMemoryMetricExporter(AggregationTemporality.DELTA)
+  metricReader = new PeriodicExportingMetricReader({ exporter: metricExporter })
+
+  meterProvider = new MeterProvider({
+    ...config.metrics,
+    readers: [...(config.metrics?.readers ?? []), metricReader],
+  })
+  metrics.setGlobalMeterProvider(meterProvider)
+}
+initOtel({})
+
+async function resetOtel(config?: OtelConfig) {
+  await spanProcessor.forceFlush()
+  spanExporter.reset()
+
+  await metricReader.forceFlush()
+  metricExporter.reset()
+
+  if (config) {
+    initOtel(config)
+  }
+}
+beforeEach(() => resetOtel())
+
+export const otel = Object.freeze({
+  /** Spans processed during the current test */
+  spans: async () => {
+    await spanProcessor.forceFlush()
+    return spanExporter.getFinishedSpans()
+  },
+  /** Metrics processed during the current test */
+  metrics: async () => {
+    await metricReader.forceFlush()
+    return metricExporter.getMetrics()
+  },
+  /** Reset OTel, optionally with a custom config */
+  reset: (config?: OtelConfig) => resetOtel(config),
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,8 +1805,6 @@ __metadata:
   resolution: "@solarwinds-apm/compat@workspace:packages/compat"
   dependencies:
     "@opentelemetry/api": "npm:^1.3.0"
-    "@opentelemetry/sdk-trace-base": "npm:~1.23.0"
-    "@opentelemetry/sdk-trace-node": "npm:~1.23.0"
     "@opentelemetry/semantic-conventions": "npm:~1.23.0"
     "@solarwinds-apm/eslint-config": "workspace:^"
     "@solarwinds-apm/rollup-config": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,19 +178,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.7.1":
-  version: 1.10.1
-  resolution: "@grpc/grpc-js@npm:1.10.1"
+"@grpc/grpc-js@npm:^1.10.6, @grpc/grpc-js@npm:^1.7.1":
+  version: 1.10.6
+  resolution: "@grpc/grpc-js@npm:1.10.6"
   dependencies:
-    "@grpc/proto-loader": "npm:^0.7.8"
-    "@types/node": "npm:>=12.12.47"
-  checksum: 10c0/51f2f898f048348073927a61e0bd615fd112a6b32b50e776ac0404bd5776d3561f2f42d64485538c2383008eabd9eaed408b67544f4261a8b3671150f73da566
+    "@grpc/proto-loader": "npm:^0.7.10"
+    "@js-sdsl/ordered-map": "npm:^4.4.2"
+  checksum: 10c0/5fc5ad0dd7fa49ddc3ccf05fa09b2c6ef20b9ff1933c574c8a3119de98b13f164c04b1bbf73bdea8f59b475d377771f4a6f8281d13b6636832676584399ef65f
   languageName: node
   linkType: hard
 
-"@grpc/proto-loader@npm:^0.7.8":
-  version: 0.7.10
-  resolution: "@grpc/proto-loader@npm:0.7.10"
+"@grpc/proto-loader@npm:^0.7.10":
+  version: 0.7.12
+  resolution: "@grpc/proto-loader@npm:0.7.12"
   dependencies:
     lodash.camelcase: "npm:^4.3.0"
     long: "npm:^5.0.0"
@@ -198,7 +198,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   bin:
     proto-loader-gen-types: build/bin/proto-loader-gen-types.js
-  checksum: 10c0/efd9a094afd90a271019adb7213dbbf6ae8788b7ad5b9b98e2b15848f0dcdd645ab8701b7feb981e3692846d4f81f71468be61bb10e85ced53dfd9a5aa2df7dd
+  checksum: 10c0/d026236f309e24fd5b840b9aefca49eb4002f270821e8194d0b622013c421b54e04df5f6b8f0797121a1e1141811a4ef088120690aea1e873701d277cd5b47fa
   languageName: node
   linkType: hard
 
@@ -370,6 +370,13 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
+  languageName: node
+  linkType: hard
+
+"@js-sdsl/ordered-map@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@js-sdsl/ordered-map@npm:4.4.2"
+  checksum: 10c0/cc7e15dc4acf6d9ef663757279600bab70533d847dcc1ab01332e9e680bd30b77cdf9ad885cc774276f51d98b05a013571c940e5b360985af5eb798dc1a2ee2b
   languageName: node
   linkType: hard
 
@@ -2050,7 +2057,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@solarwinds-apm/proto@workspace:packages/proto":
+"@solarwinds-apm/proto@workspace:^, @solarwinds-apm/proto@workspace:packages/proto":
   version: 0.0.0-use.local
   resolution: "@solarwinds-apm/proto@workspace:packages/proto"
   dependencies:
@@ -2085,7 +2092,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@solarwinds-apm/sampling@workspace:packages/sampling":
+"@solarwinds-apm/sampling@workspace:^, @solarwinds-apm/sampling@workspace:packages/sampling":
   version: 0.0.0-use.local
   resolution: "@solarwinds-apm/sampling@workspace:packages/sampling"
   dependencies:
@@ -2181,6 +2188,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@solarwinds-apm/test@workspace:packages/test"
   dependencies:
+    "@opentelemetry/api": "npm:^1.3.0"
+    "@opentelemetry/sdk-metrics": "npm:~1.23.0"
+    "@opentelemetry/sdk-trace-base": "npm:~1.23.0"
+    "@opentelemetry/sdk-trace-node": "npm:~1.23.0"
     "@solarwinds-apm/eslint-config": "workspace:^"
     "@solarwinds-apm/module": "workspace:^"
     "@solarwinds-apm/rollup-config": "workspace:^"
@@ -2587,7 +2598,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^18.19.0 || >=20.6.0, @types/node@npm:^20.6.0":
+"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:^18.19.0 || >=20.6.0, @types/node@npm:^20.6.0":
   version: 20.11.24
   resolution: "@types/node@npm:20.11.24"
   dependencies:
@@ -8171,6 +8182,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "solarwinds-apm@workspace:packages/solarwinds-apm"
   dependencies:
+    "@grpc/grpc-js": "npm:^1.10.6"
     "@opentelemetry/api": "npm:^1.3.0"
     "@opentelemetry/core": "npm:~1.23.0"
     "@opentelemetry/instrumentation": "npm:~0.50.0"
@@ -8183,7 +8195,9 @@ __metadata:
     "@solarwinds-apm/eslint-config": "workspace:^"
     "@solarwinds-apm/instrumentations": "workspace:^"
     "@solarwinds-apm/module": "workspace:^"
+    "@solarwinds-apm/proto": "workspace:^"
     "@solarwinds-apm/rollup-config": "workspace:^"
+    "@solarwinds-apm/sampling": "workspace:^"
     "@solarwinds-apm/sdk": "workspace:^"
     "@solarwinds-apm/test": "workspace:^"
     "@types/node": "npm:^20.6.0"


### PR DESCRIPTION
This adds a set of new utilities, some of them duplicating functionality from existing ones in an improved way. This is because 1. the new pure JS sampler does not have the same requirements as the existing liboboe sampler and 2. a lot of the current utilities were written ~2 years ago before I had much knowledge of OTel JS.

- New span storage/cache which is more flexible and does not require to be cleared manually
- New context utilities which are more flexible
- New parent processor which uses the new span storage and provides better information
- New headers propagator which uses the new context utilities and is cleaner overall
- The test runner now automatically sets up a clean OTel context for each test and provides an API to easily access spans and metrics produced by the test

All of the addition are also fully tested unlike some of their older counterparts (cough cough). I'll be updating the legacy components that are still required once the change to JS sampling is done, and removing the old unused ones.

Note that this PR also adds files to the `solarwinds-apm` package and not `@solarwinds-apm/sdk`. The SDK package was initially created to provide components for a distro similar to the Python concept. However OTel JS doesn't never really moved in the direction of using distro and all the components are always manually created by the `solarwinds-apm`, so we might as well move them there to simplify things a bit :)