### PR TITLE
New transaction name processor

### DIFF
--- a/.yarn/versions/9420536b.yml
+++ b/.yarn/versions/9420536b.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: minor

--- a/packages/solarwinds-apm/src/processing/parent-span.ts
+++ b/packages/solarwinds-apm/src/processing/parent-span.ts
@@ -28,9 +28,7 @@ import { spanStorage } from "../storage.js"
 const PARENT_STORAGE = spanStorage<Span | false>("solarwinds-apm parent span")
 
 /** Returns true if this span has no parent or its parent is remote */
-export function isRootOrEntry(
-  span: Span | sdk.Span | ReadableSpan,
-): span is sdk.Span {
+export function isRootOrEntry(span: Span | sdk.Span | ReadableSpan): boolean {
   const parentSpan = PARENT_STORAGE.get(span)
   return parentSpan === false || parentSpan?.spanContext().isRemote === true
 }
@@ -51,7 +49,13 @@ export function getRootOrEntry(span: Span): Span | undefined {
   return undefined
 }
 
-/** Processor that stores span parents */
+/**
+ * Processor that stores span parents
+ *
+ * This should be the last registered processor since it will clear the
+ * stored parents during {@link onEnd}, but other processors might want
+ * to access the parent during their implementation of {@link SpanProcessor.onEnd}
+ */
 export class ParentSpanProcessor
   extends NoopSpanProcessor
   implements SpanProcessor

--- a/packages/solarwinds-apm/src/processing/transaction-name.ts
+++ b/packages/solarwinds-apm/src/processing/transaction-name.ts
@@ -1,0 +1,123 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { trace } from "@opentelemetry/api"
+import type * as sdk from "@opentelemetry/sdk-trace-base"
+import {
+  NoopSpanProcessor,
+  type ReadableSpan,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base"
+import {
+  SEMATTRS_HTTP_ROUTE,
+  SEMATTRS_HTTP_TARGET,
+} from "@opentelemetry/semantic-conventions"
+import { type SwConfiguration } from "@solarwinds-apm/sdk"
+
+import { getRootOrEntry, isRootOrEntry } from "./parent-span.js"
+
+const TRANSACTION_NAME_POOL_TTL = 60 * 1000 // 1 minute
+const TRANSACTION_NAME_POOL_MAX = 200
+const TRANSACTION_NAME_DEFAULT = "other"
+const TRANSACTION_NAME_ATTRIBUTE = "sw.transaction"
+
+export function setTransactionName(name: string): boolean {
+  const active = trace.getActiveSpan()
+  const rootOrEntry = active && getRootOrEntry(active)
+  if (!rootOrEntry) {
+    return false
+  }
+
+  rootOrEntry.setAttribute(TRANSACTION_NAME_ATTRIBUTE, name)
+  return true
+}
+
+export class TransactionNameProcessor
+  extends NoopSpanProcessor
+  implements SpanProcessor
+{
+  readonly #pool = new TransactionNamePool({
+    max: TRANSACTION_NAME_POOL_MAX,
+    ttl: TRANSACTION_NAME_POOL_TTL,
+    default: TRANSACTION_NAME_DEFAULT,
+  })
+  readonly #defaultName?: string
+
+  constructor(config: SwConfiguration) {
+    super()
+    this.#defaultName = config.transactionName
+  }
+
+  override onEnd(span: ReadableSpan): void {
+    if (!isRootOrEntry(span)) {
+      return
+    }
+
+    let name = span.attributes[TRANSACTION_NAME_ATTRIBUTE]
+    if (typeof name !== "string") {
+      name = this.#defaultName ?? computedTransactionName(span)
+    }
+    name = this.#pool.registered(name)
+
+    span.attributes[TRANSACTION_NAME_ATTRIBUTE] = name
+  }
+}
+
+export function computedTransactionName(span: sdk.Span): string {
+  if (typeof process.env.AWS_LAMBDA_FUNCTION_NAME === "string") {
+    return process.env.AWS_LAMBDA_FUNCTION_NAME
+  } else if (typeof span.attributes[SEMATTRS_HTTP_ROUTE] === "string") {
+    return span.attributes[SEMATTRS_HTTP_ROUTE]
+  } else if (typeof span.attributes[SEMATTRS_HTTP_TARGET] === "string") {
+    // split on slashes and keep the first 3 segments
+    // where the first segment is an empty string before the first slash
+    return span.attributes[SEMATTRS_HTTP_TARGET].split("/", 3).join("/")
+  } else {
+    return span.name
+  }
+}
+
+export class TransactionNamePool {
+  readonly #pool = new Map<string, NodeJS.Timeout>()
+
+  readonly #max: number
+  readonly #ttl: number
+  readonly #default: string
+
+  constructor(options: { max: number; ttl: number; default: string }) {
+    this.#max = options.max
+    this.#ttl = options.ttl
+    this.#default = options.default
+  }
+
+  registered(name: string): string {
+    const existing = this.#pool.get(name)
+    if (existing !== undefined) {
+      clearTimeout(existing)
+    }
+
+    if (existing !== undefined || this.#pool.size < this.#max) {
+      const timeout = setTimeout(
+        () => this.#pool.delete(name),
+        this.#ttl,
+      ).unref()
+      this.#pool.set(name, timeout)
+      return name
+    } else {
+      return this.#default
+    }
+  }
+}

--- a/packages/solarwinds-apm/src/processing/transaction-name.ts
+++ b/packages/solarwinds-apm/src/processing/transaction-name.ts
@@ -113,6 +113,10 @@ export class TransactionNamePool {
 
   /** Given a desired transaction name return the one that should be used */
   registered(name: string): string {
+    // new name and room in pool -> add name to pool and schedule for removal after ttl -> return name
+    // new name but no room in pool -> return default name
+    // existing name -> cancel previously scheduled removal -> schedule new removal -> return name
+
     const existing = this.#pool.get(name)
     if (existing !== undefined) {
       clearTimeout(existing)

--- a/packages/solarwinds-apm/src/processing/transaction-name.ts
+++ b/packages/solarwinds-apm/src/processing/transaction-name.ts
@@ -97,7 +97,14 @@ export function computedTransactionName(span: ReadableSpan): string {
   }
 }
 
-/** A pool that prevents explosion of cardinality in transaction names */
+/**
+ * A pool that prevents explosion of cardinality in transaction names
+ *
+ * The pool only allows a certain amount of transaction names to exist
+ * at any given moment. If it is full, it will replace any name not
+ * already in the pool with a default one. The pool frees up space
+ * by pruning names that haven't been used in a given amount of time.
+ */
 export class TransactionNamePool {
   readonly #pool = new Map<string, NodeJS.Timeout>()
 

--- a/packages/solarwinds-apm/test/processing/parent-span.test.ts
+++ b/packages/solarwinds-apm/test/processing/parent-span.test.ts
@@ -21,7 +21,7 @@ import {
   getRootOrEntry,
   isRootOrEntry,
   ParentSpanProcessor,
-} from "../../src/processing/parent.js"
+} from "../../src/processing/parent-span.js"
 
 describe("ParentSpanProcessor", () => {
   before(async () => {

--- a/packages/solarwinds-apm/test/processing/transaction-name.test.ts
+++ b/packages/solarwinds-apm/test/processing/transaction-name.test.ts
@@ -1,0 +1,239 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { setTimeout } from "node:timers/promises"
+
+import { trace } from "@opentelemetry/api"
+import type * as sdk from "@opentelemetry/sdk-trace-base"
+import {
+  SEMATTRS_HTTP_ROUTE,
+  SEMATTRS_HTTP_TARGET,
+} from "@opentelemetry/semantic-conventions"
+import { type SwConfiguration } from "@solarwinds-apm/sdk"
+import { describe, expect, it, otel } from "@solarwinds-apm/test"
+
+import { ParentSpanProcessor } from "../../src/processing/parent-span.js"
+import {
+  computedTransactionName,
+  setTransactionName,
+  TransactionNamePool,
+  TransactionNameProcessor,
+} from "../../src/processing/transaction-name.js"
+
+describe("TransactionNameProcessor", () => {
+  it("sets transaction name on entry spans", async () => {
+    await otel.reset({
+      trace: {
+        processors: [
+          new TransactionNameProcessor({} as SwConfiguration),
+          new ParentSpanProcessor(),
+        ],
+      },
+    })
+
+    const tracer = trace.getTracer("test")
+    tracer.startActiveSpan("parent", (span) => {
+      expect(span.isRecording()).to.be.true
+
+      tracer.startActiveSpan("child", (span) => {
+        expect(span.isRecording()).to.be.true
+        span.end()
+      })
+
+      span.end()
+    })
+
+    const spans = await otel.spans()
+    expect(spans).to.have.lengthOf(2)
+
+    const parent = spans.find((s) => s.name === "parent")!
+    const child = spans.find((s) => s.name === "child")!
+
+    expect(parent.attributes).to.have.property("sw.transaction", "parent")
+    expect(child.attributes).not.to.have.property("sw.transaction")
+  })
+
+  it("respects configured transaction name", async () => {
+    await otel.reset({
+      trace: {
+        processors: [
+          new TransactionNameProcessor({
+            transactionName: "default",
+          } as SwConfiguration),
+          new ParentSpanProcessor(),
+        ],
+      },
+    })
+
+    const tracer = trace.getTracer("test")
+    tracer.startActiveSpan("parent", (span) => {
+      expect(span.isRecording()).to.be.true
+
+      tracer.startActiveSpan("child", (span) => {
+        expect(span.isRecording()).to.be.true
+        span.end()
+      })
+
+      span.end()
+    })
+
+    const spans = await otel.spans()
+    expect(spans).to.have.lengthOf(2)
+
+    const parent = spans.find((s) => s.name === "parent")!
+    const child = spans.find((s) => s.name === "child")!
+
+    expect(parent.attributes).to.have.property("sw.transaction", "default")
+    expect(child.attributes).not.to.have.property("sw.transaction")
+  })
+
+  it("respects custom transaction name", async () => {
+    await otel.reset({
+      trace: {
+        processors: [
+          new TransactionNameProcessor({
+            transactionName: "default",
+          } as SwConfiguration),
+          new ParentSpanProcessor(),
+        ],
+      },
+    })
+
+    const tracer = trace.getTracer("test")
+    tracer.startActiveSpan("parent", (span) => {
+      expect(span.isRecording()).to.be.true
+
+      tracer.startActiveSpan("child", (span) => {
+        expect(span.isRecording()).to.be.true
+
+        expect(setTransactionName("custom")).to.be.true
+
+        span.end()
+      })
+
+      span.end()
+    })
+
+    const spans = await otel.spans()
+    expect(spans).to.have.lengthOf(2)
+
+    const parent = spans.find((s) => s.name === "parent")!
+    const child = spans.find((s) => s.name === "child")!
+
+    expect(parent.attributes).to.have.property("sw.transaction", "custom")
+    expect(child.attributes).not.to.have.property("sw.transaction")
+  })
+
+  it("has a max cardinality of 200 + 1", async () => {
+    await otel.reset({
+      trace: {
+        processors: [
+          new TransactionNameProcessor({} as SwConfiguration),
+          new ParentSpanProcessor(),
+        ],
+      },
+    })
+
+    const tracer = trace.getTracer("test")
+    for (let i = 0; i <= 200; i++) {
+      const span = tracer.startSpan(i.toString())
+      span.end()
+    }
+
+    const spans = await otel.spans()
+    expect(spans).to.have.lengthOf(201)
+
+    const didNotMakeIt = spans.filter(
+      (span) => span.attributes["sw.transaction"] === "other",
+    )
+    expect(didNotMakeIt).to.have.lengthOf(1)
+  })
+})
+
+describe("computedTransactionName", () => {
+  it("computes normal span name", () => {
+    const span = trace.getTracer("test").startSpan("test") as sdk.Span
+    span.end()
+
+    expect(computedTransactionName(span)).to.equal("test")
+  })
+
+  it("computes routed HTTP span name", () => {
+    const span = trace.getTracer("test").startSpan("GET", {
+      attributes: {
+        [SEMATTRS_HTTP_ROUTE]: "/hello/:name",
+        [SEMATTRS_HTTP_TARGET]: "/hello/world",
+      },
+    }) as sdk.Span
+    span.end()
+
+    expect(computedTransactionName(span)).to.equal("/hello/:name")
+  })
+
+  it("computes short HTTP span name", () => {
+    const span = trace.getTracer("test").startSpan("GET", {
+      attributes: { [SEMATTRS_HTTP_TARGET]: "/cart" },
+    }) as sdk.Span
+    span.end()
+
+    expect(computedTransactionName(span)).to.equal("/cart")
+  })
+
+  it("computes long HTTP span name", () => {
+    const span = trace.getTracer("test").startSpan("GET", {
+      attributes: { [SEMATTRS_HTTP_TARGET]: "/shop/products/293/detail" },
+    }) as sdk.Span
+    span.end()
+
+    expect(computedTransactionName(span)).to.equal("/shop/products")
+  })
+
+  it("computes lambda span name", () => {
+    const init = process.env.AWS_LAMBDA_FUNCTION_NAME
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "lambda"
+
+    const span = trace.getTracer("test").startSpan("GET", {
+      attributes: {
+        [SEMATTRS_HTTP_ROUTE]: "/hello/:name",
+        [SEMATTRS_HTTP_TARGET]: "/hello/world",
+      },
+    }) as sdk.Span
+    span.end()
+
+    expect(computedTransactionName(span)).to.equal("lambda")
+
+    process.env.AWS_LAMBDA_FUNCTION_NAME = init
+  })
+})
+
+describe("TransactionNamePool", () => {
+  it("works as expected", async () => {
+    const pool = new TransactionNamePool({
+      max: 2,
+      ttl: 10,
+      default: "default",
+    })
+
+    expect(pool.registered("foo")).to.equal("foo")
+    expect(pool.registered("bar")).to.equal("bar")
+    expect(pool.registered("baz")).to.equal("default")
+    expect(pool.registered("foo")).to.equal("foo")
+
+    await setTimeout(50)
+
+    expect(pool.registered("baz")).to.equal("baz")
+  })
+})

--- a/packages/solarwinds-apm/test/sampling/grpc.test.ts
+++ b/packages/solarwinds-apm/test/sampling/grpc.test.ts
@@ -77,7 +77,7 @@ describe("GrpcSampler", () => {
         "BucketCapacity",
         "BucketRate",
       )
-    }).retries(4)
+    }).retries(16)
   })
 
   describe("invalid service key", () => {


### PR DESCRIPTION
No need for a cache or anything like that, we can just directly set the attribute on the parent with the new parent storage.