### PR TITLE
Use GitHub ARM runners and test on Node 22

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,57 +82,11 @@ jobs:
 
       - run: yarn version check
 
-  launch-arm64:
-    if: github.event_name == 'pull_request'
-    outputs:
-      matrix: ${{ steps.launch.outputs.matrix }}
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: getsentry/action-github-app-token@v3
-        id: github-token
-        with:
-          app_id: ${{ vars.APPLICATION_ID }}
-          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
-          aws-region: us-east-1
-
-      - id: launch
-        uses: solarwinds/ec2-runner-action@main
-        with:
-          action: launch
-          github-token: ${{ steps.github-token.outputs.token }}
-          matrix: |
-            16-amazonlinux2023
-            16-debian10
-            16-ubi8
-            16-ubuntu20.04
-            18-amazonlinux
-            18-debian
-            18-ubi
-            18-ubuntu
-            20-amazonlinux
-            20-debian
-            20-ubi
-            20-ubuntu
-          runner-user: github
-          runner-directory: /gh
-          instance-type: t4g.medium
-          ami-name: gha-arm64-ubuntu22-.*
-          ami-owner: "858939916050"
-          subnet-id: subnet-0fd499f8a50e41807
-          security-group-ids: sg-0fd8d8cd6effda4a5
-
   tests:
     if: github.event_name == 'pull_request'
     needs:
       - checks
-      - launch-arm64
-    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch-arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && fromJSON('{"group":"apm-arm-runner"}') || 'ubuntu-latest' }}
     strategy:
       matrix:
         image:
@@ -193,28 +147,3 @@ jobs:
         env:
           SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
           SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
-
-  terminate-arm64:
-    if: always() && github.event_name == 'pull_request'
-    needs:
-      - launch-arm64
-      - tests
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: getsentry/action-github-app-token@v3
-        id: github-token
-        with:
-          app_id: ${{ vars.APPLICATION_ID }}
-          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
-          aws-region: us-east-1
-      - uses: solarwinds/ec2-runner-action@main
-        with:
-          action: terminate
-          github-token: ${{ steps.github-token.outputs.token }}
-          matrix: ${{ needs.launch-arm64.outputs.matrix }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -105,6 +105,11 @@ jobs:
           - 20-debian
           - 20-ubi
           - 20-ubuntu
+          - 22-alpine
+          - 22-amazonlinux
+          - 22-debian
+          - 22-ubi
+          - 22-ubuntu
         arch:
           - x64
           - arm64
@@ -115,6 +120,8 @@ jobs:
           - image: 18-alpine
             arch: arm64
           - image: 20-alpine
+            arch: arm64
+          - image: 22-alpine
             arch: arm64
       fail-fast: false
     container:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,6 +28,11 @@ jobs:
           - 20-debian
           - 20-ubi
           - 20-ubuntu
+          - 22-alpine
+          - 22-amazonlinux
+          - 22-debian
+          - 22-ubi
+          - 22-ubuntu
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/docker/16-amazonlinux2023.Dockerfile
+++ b/docker/16-amazonlinux2023.Dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y \
     tar \
     xz
 
-RUN dnf install -y https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
     dnf install -y nodejs && \
     dnf clean -y all
 

--- a/docker/16-ubi8.Dockerfile
+++ b/docker/16-ubi8.Dockerfile
@@ -8,7 +8,7 @@ RUN dnf install -y \
     xz
 
 RUN dnf module disable -y nodejs && \
-    dnf install -y https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+    curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
     dnf install -y nodejs && \
     dnf clean -y all
 

--- a/docker/16-ubuntu20.04.Dockerfile
+++ b/docker/16-ubuntu20.04.Dockerfile
@@ -8,9 +8,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     xz-utils
 
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean

--- a/docker/18-amazonlinux.Dockerfile
+++ b/docker/18-amazonlinux.Dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y \
     tar \
     xz
 
-RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
+RUN curl -fsSL https://rpm.nodesource.com/setup_18.x | bash - && \
     dnf install -y nodejs && \
     dnf clean -y all
 

--- a/docker/18-amazonlinux.Dockerfile
+++ b/docker/18-amazonlinux.Dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y \
     tar \
     xz
 
-RUN dnf install -y https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
     dnf install -y nodejs && \
     dnf clean -y all
 

--- a/docker/18-ubi.Dockerfile
+++ b/docker/18-ubi.Dockerfile
@@ -8,8 +8,10 @@ RUN dnf install -y \
     xz
 
 RUN dnf module disable -y nodejs && \
-    curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
+    update-crypto-policies --set LEGACY && \
+    curl -fsSL https://rpm.nodesource.com/setup_18.x | bash - && \
     dnf install -y nodejs && \
+    update-crypto-policies --set DEFAULT && \
     dnf clean -y all
 
 RUN corepack enable

--- a/docker/18-ubi.Dockerfile
+++ b/docker/18-ubi.Dockerfile
@@ -8,10 +8,8 @@ RUN dnf install -y \
     xz
 
 RUN dnf module disable -y nodejs && \
-    dnf install -y https://rpm.nodesource.com/pub_18.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
-    update-crypto-policies --set LEGACY && \
+    curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
     dnf install -y nodejs && \
-    update-crypto-policies --set DEFAULT && \
     dnf clean -y all
 
 RUN corepack enable

--- a/docker/18-ubuntu.Dockerfile
+++ b/docker/18-ubuntu.Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     git \
     git-lfs \
-    gnupg \
     xz-utils
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \

--- a/docker/18-ubuntu.Dockerfile
+++ b/docker/18-ubuntu.Dockerfile
@@ -8,9 +8,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     xz-utils
 
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean

--- a/docker/20-amazonlinux.Dockerfile
+++ b/docker/20-amazonlinux.Dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y \
     tar \
     xz
 
-RUN dnf install -y https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
+RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
     dnf install -y nodejs && \
     dnf clean -y all
 

--- a/docker/20-amazonlinux.Dockerfile
+++ b/docker/20-amazonlinux.Dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y \
     tar \
     xz
 
-RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
+RUN curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
     dnf install -y nodejs && \
     dnf clean -y all
 

--- a/docker/20-ubi.Dockerfile
+++ b/docker/20-ubi.Dockerfile
@@ -8,8 +8,10 @@ RUN dnf install -y \
     xz
 
 RUN dnf module disable -y nodejs && \
-    curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
+    update-crypto-policies --set LEGACY && \
+    curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
     dnf install -y nodejs && \
+    update-crypto-policies --set DEFAULT && \
     dnf clean -y all
 
 RUN corepack enable

--- a/docker/20-ubi.Dockerfile
+++ b/docker/20-ubi.Dockerfile
@@ -8,10 +8,8 @@ RUN dnf install -y \
     xz
 
 RUN dnf module disable -y nodejs && \
-    dnf install -y https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm && \
-    update-crypto-policies --set LEGACY && \
+    curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
     dnf install -y nodejs && \
-    update-crypto-policies --set DEFAULT && \
     dnf clean -y all
 
 RUN corepack enable

--- a/docker/20-ubuntu.Dockerfile
+++ b/docker/20-ubuntu.Dockerfile
@@ -8,9 +8,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     xz-utils
 
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean

--- a/docker/20-ubuntu.Dockerfile
+++ b/docker/20-ubuntu.Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     git \
     git-lfs \
-    gnupg \
     xz-utils
 
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \

--- a/docker/22-alpine.Dockerfile
+++ b/docker/22-alpine.Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+RUN apk add --no-cache \
+    curl \
+    gcompat \
+    git \
+    git-lfs \
+    libc6-compat \
+    tar \
+    xz
+
+RUN corepack enable
+
+WORKDIR /solarwinds-apm
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/docker/22-amazonlinux.Dockerfile
+++ b/docker/22-amazonlinux.Dockerfile
@@ -1,0 +1,17 @@
+FROM amazonlinux
+
+RUN dnf install -y \
+    curl-minimal \
+    git \
+    git-lfs \
+    tar \
+    xz
+
+RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - && \
+    dnf install -y nodejs && \
+    dnf clean -y all
+
+RUN corepack enable
+
+WORKDIR /solarwinds-apm
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/docker/22-debian.Dockerfile
+++ b/docker/22-debian.Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    git-lfs \
+    xz-utils \
+    && apt-get clean
+
+RUN corepack enable
+
+WORKDIR /solarwinds-apm
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/docker/22-ubi.Dockerfile
+++ b/docker/22-ubi.Dockerfile
@@ -1,0 +1,20 @@
+FROM registry.access.redhat.com/ubi9
+
+RUN dnf install -y \
+    curl-minimal \
+    git \
+    git-lfs \
+    tar \
+    xz
+
+RUN dnf module disable -y nodejs && \
+    update-crypto-policies --set LEGACY && \
+    curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - && \
+    dnf install -y nodejs && \
+    update-crypto-policies --set DEFAULT && \
+    dnf clean -y all
+
+RUN corepack enable
+
+WORKDIR /solarwinds-apm
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/docker/22-ubuntu.Dockerfile
+++ b/docker/22-ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     git-lfs \
     xz-utils
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get update && \
     apt-get install -y nodejs && \
     apt-get clean

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -148,6 +148,52 @@ services:
       - apm-collector
       - otel-collector
 
+  22-alpine:
+    build:
+      context: .
+      dockerfile: 22-alpine.Dockerfile
+    volumes:
+      - ..:/solarwinds-apm
+    links:
+      - apm-collector
+      - otel-collector
+  22-amazonlinux:
+    build:
+      context: .
+      dockerfile: 22-amazonlinux.Dockerfile
+    volumes:
+      - ..:/solarwinds-apm
+    links:
+      - apm-collector
+      - otel-collector
+  22-debian:
+    build:
+      context: .
+      dockerfile: 22-debian.Dockerfile
+    volumes:
+      - ..:/solarwinds-apm
+    links:
+      - apm-collector
+      - otel-collector
+  22-ubi:
+    build:
+      context: .
+      dockerfile: 22-ubi.Dockerfile
+    volumes:
+      - ..:/solarwinds-apm
+    links:
+      - apm-collector
+      - otel-collector
+  22-ubuntu:
+    build:
+      context: .
+      dockerfile: 22-ubuntu.Dockerfile
+    volumes:
+      - ..:/solarwinds-apm
+    links:
+      - apm-collector
+      - otel-collector
+
   example:
     build:
       context: .
@@ -196,7 +242,7 @@ services:
     volumes:
       - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
   postgres:
-    image: postgres:15
+    image: postgres:16
     environment:
       POSTGRES_PASSWORD: postgres
     volumes:


### PR DESCRIPTION
Switches from the EC2 runners to the new GitHub ARM runners. Also add test matrix for Node.js 22, which is the next LTS release.