### PR TITLE
Use user-provided OTel API whenever possible in Lambda

### DIFF
--- a/lambda/package.json
+++ b/lambda/package.json
@@ -6,6 +6,7 @@
     "{{name}}": "{{version}}",
     "@opentelemetry/api": "{{api-version}}",
     "@opentelemetry/exporter-trace-otlp-grpc": "{{exporters-version}}",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "{{exporters-version}}"
+    "@opentelemetry/exporter-metrics-otlp-grpc": "{{exporters-version}}",
+    "semver": "^7"
   }
 }

--- a/lambda/shim.cjs
+++ b/lambda/shim.cjs
@@ -1,1 +1,0 @@
-require("{{name}}")

--- a/lambda/shim.mjs
+++ b/lambda/shim.mjs
@@ -1,1 +1,58 @@
-await import("{{name}}")
+import fs from "node:fs"
+import path from "node:path"
+import satisfies from "semver/functions/satisfies"
+
+try {
+  const BUNDLED_API = "/opt/solarwinds-apm/node_modules/@opentelemetry/api"
+  const dirs = []
+
+  // Add relative node_modules dirs to the search paths
+  const TASK_ROOT = process.env.LAMBDA_TASK_ROOT
+  if (TASK_ROOT) {
+    let dir = TASK_ROOT
+    while (true) {
+      dirs.push(path.join(dir, "node_modules"))
+
+      const parent = path.dirname(dir)
+      if (dir !== parent) {
+        dir = parent
+      } else {
+        break
+      }
+    }
+  }
+
+  // Add entries from NODE_PATH to the search paths
+  const NODE_PATH = process.env.NODE_PATH?.split(":") ?? []
+  dirs.push(...NODE_PATH)
+
+  // Search for a use-provided OTel API
+  for (const dir of dirs) {
+    const api = path.join(dir, "@opentelemetry", "api")
+    let version
+    try {
+      // Try and read the package.json version in this search path
+      version = JSON.parse(
+        fs.readFileSync(path.join(api, "package.json"), { encoding: "utf-8" }),
+      ).version
+    } catch {
+      // No valid package.json found, search next path
+      continue
+    }
+
+    try {
+      // Try and override our bundled OTel API if the user provides it
+      if (satisfies(version, "{{api-version}}")) {
+        fs.rmSync(BUNDLED_API, { recursive: true, force: true })
+        fs.symlinkSync(api, BUNDLED_API)
+      }
+    } catch {
+      // Something is wrong, bail
+      break
+    }
+  }
+
+  await import("{{name}}")
+} catch (error) {
+  console.error(error)
+}

--- a/lambda/shim.mjs
+++ b/lambda/shim.mjs
@@ -1,6 +1,6 @@
 import fs from "node:fs"
 import path from "node:path"
-import satisfies from "semver/functions/satisfies"
+import satisfies from "semver/functions/satisfies.js"
 
 try {
   const BUNDLED_API = "/opt/solarwinds-apm/node_modules/@opentelemetry/api"

--- a/lambda/shim.mjs
+++ b/lambda/shim.mjs
@@ -26,7 +26,7 @@ try {
   const NODE_PATH = process.env.NODE_PATH?.split(":") ?? []
   dirs.push(...NODE_PATH)
 
-  // Search for a use-provided OTel API
+  // Search for a user-provided OTel API
   for (const dir of dirs) {
     const api = path.join(dir, "@opentelemetry", "api")
     let version
@@ -46,13 +46,14 @@ try {
         fs.rmSync(BUNDLED_API, { recursive: true, force: true })
         fs.symlinkSync(api, BUNDLED_API)
       }
-    } catch {
+    } catch (error) {
       // Something is wrong, bail
+      console.error("error while detecting @opentelemetry/api")
       break
     }
   }
 
   await import("{{name}}")
 } catch (error) {
-  console.error(error)
+  console.error("error while loading solarwinds-apm", error)
 }

--- a/lambda/wrapper
+++ b/lambda/wrapper
@@ -1,11 +1,5 @@
 #!/bin/bash
-
-# Only use --require to load if SW_APM_CJS is set
-if [ -z "${SW_APM_CJS}" ]; then
-    export NODE_OPTIONS="${NODE_OPTIONS} --import /opt/solarwinds-apm/shim.mjs"
-else
-    export NODE_OPTIONS="${NODE_OPTIONS} --require /opt/solarwinds-apm/shim.cjs"
-fi
+export NODE_OPTIONS="${NODE_OPTIONS} --import /opt/solarwinds-apm/shim.mjs"
 
 # The default for Node is http/proto but we only include the gRPC exporters
 export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"

--- a/scripts/lambda.js
+++ b/scripts/lambda.js
@@ -56,7 +56,6 @@ rm("lambda/layer.zip")
 rm("node_modules/.lambda", { recursive: true })
 cpSync("lambda", "node_modules/.lambda", { recursive: true })
 replace("node_modules/.lambda/package.json")
-replace("node_modules/.lambda/shim.cjs")
 replace("node_modules/.lambda/shim.mjs")
 
 execSync("touch yarn.lock && yarn install", {
@@ -102,9 +101,6 @@ archive.directory(
   "node_modules/.lambda/node_modules/",
   "solarwinds-apm/node_modules/",
 )
-archive.file("node_modules/.lambda/shim.cjs", {
-  name: "solarwinds-apm/shim.cjs",
-})
 archive.file("node_modules/.lambda/shim.mjs", {
   name: "solarwinds-apm/shim.mjs",
 })


### PR DESCRIPTION
This searches for an `@opentelemetry/api` package within the same search paths as the user handler would, and if one is found that's compatible with the library overrides the version we bundle with it.