### PR TITLE
Move logger and init message logic, stop building CommonJS

### DIFF
--- a/.yarn/versions/548d9043.yml
+++ b/.yarn/versions/548d9043.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: minor

--- a/examples/next-prisma/package.json
+++ b/examples/next-prisma/package.json
@@ -2,7 +2,7 @@
   "name": "@solarwinds-apm/example-next-prisma",
   "private": true,
   "scripts": {
-    "build": "prisma generate && prisma migrate deploy && next build",
+    "build:skip": "prisma generate && prisma migrate deploy && next build",
     "lint": "next lint",
     "start": "prisma generate && prisma migrate deploy && next start"
   },

--- a/packages/instrumentations/COMPATIBILITY.md
+++ b/packages/instrumentations/COMPATIBILITY.md
@@ -34,7 +34,7 @@
 | `lru-memoizer`              | `>=1.3.0 <3.0.0`   | `@opentelemetry/instrumentation-lru-memoizer`     |
 | `memcached`                 | `>=2.2.0 <3.0.0`   | `@opentelemetry/instrumentation-memcached`        |
 | `mongodb`                   | `>=3.3.0 <7.0.0`   | `@opentelemetry/instrumentation-mongodb`          |
-| `mongoose`                  | `>=5.9.7 <7.0.0`   | `@opentelemetry/instrumentation-mongoose`         |
+| `mongoose`                  | `>=5.9.7 <9.0.0`   | `@opentelemetry/instrumentation-mongoose`         |
 | `mysql`                     | `>=2.0.0 <3.0.0`   | `@opentelemetry/instrumentation-mysql`            |
 | `mysql2`                    | `>=1.4.2 <4.0.0`   | `@opentelemetry/instrumentation-mysql2`           |
 | `net`                       | `*`                | `@opentelemetry/instrumentation-net`              |
@@ -45,5 +45,5 @@
 | `restify`                   | `>=4.0.0 <12.0.0`  | `@opentelemetry/instrumentation-restify`          |
 | `router`                    | `>=1.0.0 <2.0.0`   | `@opentelemetry/instrumentation-router`           |
 | `socket.io`                 | `>=2.0.0 <5.0.0`   | `@opentelemetry/instrumentation-socket.io`        |
-| `tedious`                   | `>=1.11.0 <18.0.0` | `@opentelemetry/instrumentation-tedious`          |
+| `tedious`                   | `>=1.11.0 <20.0.0` | `@opentelemetry/instrumentation-tedious`          |
 | `winston`                   | `>=1.0.0 <4.0.0`   | `@opentelemetry/instrumentation-winston`          |

--- a/packages/rollup-config/index.js
+++ b/packages/rollup-config/index.js
@@ -23,7 +23,7 @@ import typescript from "@rollup/plugin-typescript"
 import globby from "globby"
 import nodeExternals from "rollup-plugin-node-externals"
 
-const FORMATS = ["es", "cjs"]
+const FORMATS = ["es"]
 
 async function task(src, dist, format, sources) {
   const dir = path.join(dist, format)

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -71,6 +71,7 @@
     "@opentelemetry/sdk-trace-node": "~1.26.0",
     "@opentelemetry/semantic-conventions": "~1.27.0",
     "@solarwinds-apm/bindings": "workspace:^",
+    "@solarwinds-apm/dependencies": "workspace:^",
     "@solarwinds-apm/instrumentations": "workspace:^",
     "@solarwinds-apm/lazy": "workspace:^",
     "@solarwinds-apm/module": "workspace:^",

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -77,6 +77,7 @@
     "@solarwinds-apm/proto": "workspace:^",
     "@solarwinds-apm/sampling": "workspace:^",
     "@solarwinds-apm/sdk": "workspace:^",
+    "json-stringify-safe": "^5.0.1",
     "semver": "^7.5.4",
     "zod": "^3.22.4"
   },

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -32,8 +32,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/es/index.es.js",
-      "require": "./dist/cjs/index.cjs.js"
+      "import": "./dist/es/index.es.js"
     },
     "./loader": {
       "import": "./dist/es/hooks.es.js"

--- a/packages/solarwinds-apm/src/logger.ts
+++ b/packages/solarwinds-apm/src/logger.ts
@@ -1,0 +1,72 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import process from "node:process"
+import util from "node:util"
+
+import { type DiagLogFunction, type DiagLogger } from "@opentelemetry/api"
+import stringify from "json-stringify-safe"
+
+const COLOURS = {
+  red: "\x1b[1;31m",
+  yellow: "\x1b[1;33m",
+  cyan: "\x1b[1;36m",
+}
+
+export class Logger implements DiagLogger {
+  readonly error = Logger.makeLogger("error", "red")
+  readonly warn = Logger.makeLogger("warn", "yellow")
+  readonly info = Logger.makeLogger("info", "cyan")
+  readonly debug = Logger.makeLogger("debug")
+  readonly verbose = Logger.makeLogger("verbose")
+
+  private static makeLogger(
+    level: string,
+    colour?: keyof typeof COLOURS,
+  ): DiagLogFunction {
+    if (process.stdout.isTTY && process.stdout.hasColors(16)) {
+      const colourCode = colour && COLOURS[colour]
+
+      return (message, ...args) => {
+        let line = `[${new Date().toISOString()}] (`
+
+        if (colourCode) {
+          line += colourCode
+        }
+        line += level.toUpperCase()
+        if (colourCode) {
+          line += "\x1b[0m"
+        }
+
+        line += `) ${message}`
+        for (const arg of args) {
+          const string = util.inspect(arg, false, Infinity, true)
+          line += ` ${string}`
+        }
+
+        console.log(line)
+      }
+    } else {
+      return (message, ...args) => {
+        while (typeof args[0] === "string") {
+          message += ` ${args.shift() as string}`
+        }
+
+        console.log(stringify({ time: new Date(), level, message, args }))
+      }
+    }
+  }
+}

--- a/packages/solarwinds-apm/src/metadata.ts
+++ b/packages/solarwinds-apm/src/metadata.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import fs from "node:fs/promises"
+import process from "node:process"
+
+import { type Attributes } from "@opentelemetry/api"
+import { dependencies } from "@solarwinds-apm/dependencies"
+import semver from "semver"
+
+let version: string
+try {
+  const json = await fs.readFile("../package.json", { encoding: "utf-8" })
+  const parsed = JSON.parse(json) as Record<string, unknown>
+  if (typeof parsed.version === "string") {
+    version = parsed.version
+  } else {
+    // Should never happen
+    version = null!
+  }
+} catch {
+  // Should also never happen
+  version = null!
+}
+export const VERSION = version
+
+/**
+ * Versions of the dependencies of Node.js itself
+ */
+export const VERSIONS: Attributes = Object.fromEntries(
+  Object.entries(process.versions)
+    .filter(([name]) => name !== "node")
+    .map(([name, version]) => [`node.${name}.version`, version]),
+)
+
+/**
+ * Versions of the dependencies available to the Node.js process
+ */
+export async function modules(): Promise<Attributes> {
+  const modules = await dependencies()
+  return Object.fromEntries(
+    [...modules].map(([name, versions]) => [
+      `node.${name}.versions`,
+      [...versions].sort(semver.compare),
+    ]),
+  )
+}

--- a/packages/solarwinds-apm/test/appoptics/reporter.test.ts
+++ b/packages/solarwinds-apm/test/appoptics/reporter.test.ts
@@ -1,0 +1,108 @@
+/*
+Copyright 2023-2024 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Resource } from "@opentelemetry/resources"
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
+import {
+  ATTR_PROCESS_COMMAND_ARGS,
+  ATTR_PROCESS_COMMAND_LINE,
+} from "@opentelemetry/semantic-conventions/incubating"
+import { describe, expect, it } from "@solarwinds-apm/test"
+
+import { init } from "../../src/appoptics/reporter.js"
+
+const lit = process.platform === "linux" ? it : it.skip.bind(it)
+
+describe("init", () => {
+  lit("has right basic properties", async () => {
+    const message = Object.fromEntries(await init(new Resource({})))
+
+    expect(message).to.include({
+      __Init: true,
+      Layer: "nodejs",
+      Label: "single",
+    })
+    expect(message).to.include.keys(["APM.Version", "APM.Extension.Version"])
+  }).timeout(10_000)
+
+  lit("forwards basic resource properties", async () => {
+    const props = {
+      s: "string",
+      n: 2,
+      b: true,
+    }
+    const message = Object.fromEntries(await init(new Resource(props)))
+
+    expect(message).to.include(props)
+  }).timeout(10_000)
+
+  lit("doesn't forward service name", async () => {
+    const message = Object.fromEntries(
+      await init(new Resource({ [ATTR_SERVICE_NAME]: "value" })),
+    )
+
+    expect(message).not.to.have.key(ATTR_SERVICE_NAME)
+  }).timeout(10_000)
+
+  lit("converts array or undefined resource properties", async () => {
+    const message = Object.fromEntries(
+      await init(
+        new Resource({
+          array: [],
+          undefined: undefined,
+        }),
+      ),
+    )
+
+    expect(message).to.include({
+      array: "",
+      undefined: null,
+    })
+  }).timeout(10_000)
+
+  lit("converts process command args to command line", async () => {
+    const message = Object.fromEntries(
+      await init(
+        new Resource({
+          [ATTR_PROCESS_COMMAND_ARGS]: ["node", "index.js"],
+        }),
+      ),
+    )
+
+    expect(message).to.include({
+      [ATTR_PROCESS_COMMAND_LINE]: "node index.js",
+    })
+    expect(message).not.to.have.key(ATTR_PROCESS_COMMAND_ARGS)
+  }).timeout(10_000)
+
+  lit("doesn't override base attributes with resource attributes", async () => {
+    const message = Object.fromEntries(
+      await init(
+        new Resource({
+          __Init: false,
+          Layer: "python",
+          Label: "multiple",
+        }),
+      ),
+    )
+
+    expect(message).to.include({
+      __Init: true,
+      Layer: "nodejs",
+      Label: "single",
+    })
+  }).timeout(10_000)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7993,6 +7993,7 @@ __metadata:
     "@types/node": "npm:^18.19.43"
     "@types/semver": "npm:^7.5.3"
     eslint: "npm:^9.9.1"
+    json-stringify-safe: "npm:^5.0.1"
     prettier: "npm:^3.3.3"
     rollup: "npm:^4.3.0"
     semver: "npm:^7.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7981,6 +7981,7 @@ __metadata:
     "@opentelemetry/sdk-trace-node": "npm:~1.26.0"
     "@opentelemetry/semantic-conventions": "npm:~1.27.0"
     "@solarwinds-apm/bindings": "workspace:^"
+    "@solarwinds-apm/dependencies": "workspace:^"
     "@solarwinds-apm/eslint-config": "workspace:^"
     "@solarwinds-apm/instrumentations": "workspace:^"
     "@solarwinds-apm/lazy": "workspace:^"


### PR DESCRIPTION
Still moving things over with minor changes, this contains the first usage of ESM only features which broke CommonJS builds, so they are disabled now, which is the first step to doing all ESM :)