### PR TITLE
Add options to log to stderr and to drop all logs

### DIFF
--- a/.yarn/versions/8fd16501.yml
+++ b/.yarn/versions/8fd16501.yml
@@ -1,0 +1,13 @@
+releases:
+  "@solarwinds-apm/sampling": patch
+  solarwinds-apm: minor
+
+declined:
+  - "@solarwinds-apm/bindings"
+  - "@solarwinds-apm/compat"
+  - "@solarwinds-apm/dependencies"
+  - "@solarwinds-apm/eslint-config"
+  - "@solarwinds-apm/histogram"
+  - "@solarwinds-apm/instrumentations"
+  - "@solarwinds-apm/module"
+  - "@solarwinds-apm/test"

--- a/examples/eslint.config.js
+++ b/examples/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/express-mysql/index.js
+++ b/examples/express-mysql/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/fastify-postgres/index.js
+++ b/examples/fastify-postgres/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/fastify-postgres/solarwinds.apm.config.js
+++ b/examples/fastify-postgres/solarwinds.apm.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/hello-distributed/external.js
+++ b/examples/hello-distributed/external.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/hello-distributed/internal.js
+++ b/examples/hello-distributed/internal.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/hello-manual/index.js
+++ b/examples/hello-manual/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/hello/index.js
+++ b/examples/hello/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/build.js
+++ b/packages/bindings/build.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/eslint.config.js
+++ b/packages/bindings/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/index.js
+++ b/packages/bindings/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/oboe.js
+++ b/packages/bindings/oboe.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/test/oboe.test.ts
+++ b/packages/bindings/test/oboe.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/types/index.d.ts
+++ b/packages/bindings/types/index.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/types/metrics.d.ts
+++ b/packages/bindings/types/metrics.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/bindings/types/oboe.d.ts
+++ b/packages/bindings/types/oboe.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/compat/eslint.config.js
+++ b/packages/compat/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/compat/test/index.test.ts
+++ b/packages/compat/test/index.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/dependencies/eslint.config.js
+++ b/packages/dependencies/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/dependencies/src/index.ts
+++ b/packages/dependencies/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/dependencies/src/node-modules.ts
+++ b/packages/dependencies/src/node-modules.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/dependencies/src/pnp-api.ts
+++ b/packages/dependencies/src/pnp-api.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/dependencies/test/index.test.ts
+++ b/packages/dependencies/test/index.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/histogram/eslint.config.js
+++ b/packages/histogram/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/histogram/src/explicit.ts
+++ b/packages/histogram/src/explicit.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/histogram/src/exponential.ts
+++ b/packages/histogram/src/exponential.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/histogram/src/index.ts
+++ b/packages/histogram/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/instrumentations/eslint.config.js
+++ b/packages/instrumentations/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/instrumentations/src/compatibility.ts
+++ b/packages/instrumentations/src/compatibility.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/instrumentations/src/index.ts
+++ b/packages/instrumentations/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/instrumentations/src/resource-detector-uams.ts
+++ b/packages/instrumentations/src/resource-detector-uams.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/instrumentations/test/resource-detector-uams.test.ts
+++ b/packages/instrumentations/test/resource-detector-uams.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/module/eslint.config.js
+++ b/packages/module/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/module/src/index.ts
+++ b/packages/module/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/eslint.config.js
+++ b/packages/sampling/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/src/dice.ts
+++ b/packages/sampling/src/dice.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/src/index.ts
+++ b/packages/sampling/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/src/metrics.ts
+++ b/packages/sampling/src/metrics.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -368,8 +368,6 @@ export abstract class OboeSampler implements Sampler {
    * the subclass whenever the remote settings are updated.
    */
   protected updateSettings(settings: Settings): void {
-    this.logger.debug("settings updated", settings)
-
     if (settings.timestamp > (this.#settings?.timestamp ?? 0)) {
       this.#settings = settings
 

--- a/packages/sampling/src/settings.ts
+++ b/packages/sampling/src/settings.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/src/token-bucket.ts
+++ b/packages/sampling/src/token-bucket.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/src/trace-options.ts
+++ b/packages/sampling/src/trace-options.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/test/dice.test.ts
+++ b/packages/sampling/test/dice.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/test/sampler.test.ts
+++ b/packages/sampling/test/sampler.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/test/settings.test.ts
+++ b/packages/sampling/test/settings.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/test/token-bucket.test.ts
+++ b/packages/sampling/test/token-bucket.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/sampling/test/trace-options.test.ts
+++ b/packages/sampling/test/trace-options.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/CONFIGURATION.md
+++ b/packages/solarwinds-apm/CONFIGURATION.md
@@ -70,6 +70,8 @@ The following log levels are available in increasing order of verbosity.
 - `verbose`
 - `all`
 
+By default the instrumentation logs are printed to stdout, but it's possible to direct them to stderr instead by setting the `SW_APM_LOG_STDERR` environment variable to any value, or even drop all logs entirely by setting the `SW_APM_LOG_NULL` environment variable.
+
 ### Logs Export
 
 It is possible to export logs to the collector by explicitly enabling the feature. This feature integrates directly with select logging libraries listed below. Support will be added to more libraries in the future if requested.

--- a/packages/solarwinds-apm/build.js
+++ b/packages/solarwinds-apm/build.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/eslint.config.js
+++ b/packages/solarwinds-apm/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/lib.d.ts
+++ b/packages/solarwinds-apm/lib.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/api.ts
+++ b/packages/solarwinds-apm/src/api.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/appoptics/certificate.ts
+++ b/packages/solarwinds-apm/src/appoptics/certificate.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/appoptics/exporters/metrics.ts
+++ b/packages/solarwinds-apm/src/appoptics/exporters/metrics.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/appoptics/exporters/traces.ts
+++ b/packages/solarwinds-apm/src/appoptics/exporters/traces.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/appoptics/processing/inbound-metrics.ts
+++ b/packages/solarwinds-apm/src/appoptics/processing/inbound-metrics.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/appoptics/reporter.ts
+++ b/packages/solarwinds-apm/src/appoptics/reporter.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/appoptics/sampler.ts
+++ b/packages/solarwinds-apm/src/appoptics/sampler.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/backoff.ts
+++ b/packages/solarwinds-apm/src/backoff.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-import assert from "node:assert"
 
 export interface BackoffOptions {
   /** Initial backoff time */
@@ -41,15 +39,14 @@ export class Backoff {
   }
 
   constructor(options: BackoffOptions) {
-    assert(options.initial > 0, "initial backup value should be positive")
-    if (options.max) {
-      assert(
-        options.max >= options.initial,
-        "max backoff should be greater than initial",
-      )
+    if (options.initial <= 0) {
+      throw new TypeError("initial backup value should be positive")
     }
-    if (options.retries) {
-      assert(options.retries > 0, "max retries should be positive")
+    if (options.max !== undefined && options.max < options.initial) {
+      throw new TypeError("max backoff should be greater than initial")
+    }
+    if (options.retries !== undefined && options.retries <= 0) {
+      throw new Error("max retries should be positive")
     }
 
     this.#backoff = {

--- a/packages/solarwinds-apm/src/commonjs/api.d.ts
+++ b/packages/solarwinds-apm/src/commonjs/api.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/commonjs/api.js
+++ b/packages/solarwinds-apm/src/commonjs/api.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/commonjs/flags.d.ts
+++ b/packages/solarwinds-apm/src/commonjs/flags.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/commonjs/flags.js
+++ b/packages/solarwinds-apm/src/commonjs/flags.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/commonjs/index.d.ts
+++ b/packages/solarwinds-apm/src/commonjs/index.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/commonjs/index.js
+++ b/packages/solarwinds-apm/src/commonjs/index.js
@@ -5,7 +5,7 @@ if (require("./version")) {
   if (global[require("./flags").INIT] !== true) {
     // this will not trigger if customers use the --import flag then use require,
     // it will only trigger if they only ever use require
-    console.warn(
+    require("./log")(
       "This library (solarwinds-apm) no longer supports loading via require. " +
         "The application may not be instrumented."
     );

--- a/packages/solarwinds-apm/src/commonjs/log.d.ts
+++ b/packages/solarwinds-apm/src/commonjs/log.d.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+declare const log: typeof console.log | typeof console.error;
+export = log;

--- a/packages/solarwinds-apm/src/commonjs/log.js
+++ b/packages/solarwinds-apm/src/commonjs/log.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module.exports =
+  "SW_APM_LOG_STDERR" in process.env ? console.error : console.log;

--- a/packages/solarwinds-apm/src/commonjs/log.js
+++ b/packages/solarwinds-apm/src/commonjs/log.js
@@ -14,5 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-module.exports =
-  "SW_APM_LOG_STDERR" in process.env ? console.error : console.log;
+if ("SW_APM_LOG_STDERR" in process.env) {
+  module.exports = console.error;
+} else if ("SW_APM_LOG_NULL" in process.env) {
+  module.exports = function () {
+    // drop the logs
+  };
+} else {
+  module.exports = console.log;
+}

--- a/packages/solarwinds-apm/src/commonjs/version.d.ts
+++ b/packages/solarwinds-apm/src/commonjs/version.d.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/commonjs/version.js
+++ b/packages/solarwinds-apm/src/commonjs/version.js
@@ -4,6 +4,7 @@
 var fs = require("fs");
 var path = require("path");
 var process = require("process");
+var log = require("./log");
 
 try {
   if (
@@ -66,21 +67,21 @@ try {
 
   module.exports = true;
 } catch (error) {
-  console.warn(error);
+  log(error);
   module.exports = false;
 }
 
 try {
   var node = process.versions.node;
-  console.log("Node.js " + node);
+  log("Node.js " + node);
 
   var solarwinds = JSON.parse(
     fs.readFileSync(path.join(__dirname, "../../package.json"), {
       encoding: "utf8"
     })
   ).version;
-  console.log("solarwinds-apm " + solarwinds);
+  log("solarwinds-apm " + solarwinds);
 
   var otel = require("@opentelemetry/core").VERSION;
-  console.log("@opentelemetry/core " + otel);
+  log("@opentelemetry/core " + otel);
 } catch (_error) {}

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -32,6 +32,8 @@ import { IS_SERVERLESS } from "@solarwinds-apm/module"
 import { load } from "@solarwinds-apm/module"
 import { z, ZodError, ZodIssueCode } from "zod"
 
+import log from "./commonjs/log.js"
+
 const PREFIX = "SW_APM_"
 const ENDPOINTS = {
   traces: "/v1/traces",
@@ -259,10 +261,10 @@ export async function read(): Promise<Configuration> {
         file = read
         source = option
       } catch (error) {
-        console.warn(`The config file (${option}) could not be read.`, error)
+        log(`The config file (${option}) could not be read.`, error)
       }
     } else if (paths.length === 1) {
-      console.warn(`The config file (${option}) could not be found.`)
+      log(`The config file (${option}) could not be found.`)
     }
   }
 
@@ -283,7 +285,7 @@ export async function read(): Promise<Configuration> {
   const appoptics = raw.collector.hostname.includes("appoptics")
   const legacy = raw.legacy ?? appoptics
   if (legacy && raw.exportLogsEnabled) {
-    console.warn("Logs export is not supported when exporting to AppOptics.")
+    log("Logs export is not supported when exporting to AppOptics.")
     raw.exportLogsEnabled = false
   }
 
@@ -348,10 +350,10 @@ export function printError(err: unknown) {
       }
 
     for (const issue of err.issues.flatMap(formatIssue(1))) {
-      console.warn(issue)
+      log(issue)
     }
   } else {
-    console.warn(err)
+    log(err)
   }
 }
 

--- a/packages/solarwinds-apm/src/exporters/logs.ts
+++ b/packages/solarwinds-apm/src/exporters/logs.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/exporters/metrics.ts
+++ b/packages/solarwinds-apm/src/exporters/metrics.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/exporters/traces.ts
+++ b/packages/solarwinds-apm/src/exporters/traces.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/hooks.js
+++ b/packages/solarwinds-apm/src/hooks.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/index.ts
+++ b/packages/solarwinds-apm/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/index.ts
+++ b/packages/solarwinds-apm/src/index.ts
@@ -18,6 +18,7 @@ import { IS_SERVERLESS } from "@solarwinds-apm/module"
 import { register } from "module"
 
 import { INIT } from "./commonjs/flags.js"
+import log from "./commonjs/log.js"
 import { init } from "./init.js"
 
 if (!IS_SERVERLESS) {
@@ -43,7 +44,7 @@ if (!Reflect.has(globalThis, INIT)) {
       writable: false,
     })
   } catch (error) {
-    console.error(error)
+    log(error)
   }
 }
 

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -41,6 +41,7 @@ import {
 } from "@solarwinds-apm/instrumentations"
 import { IS_AWS_LAMBDA } from "@solarwinds-apm/module"
 
+import log from "./commonjs/log.js"
 import { type Configuration, printError, read } from "./config.js"
 import { componentLogger, Logger } from "./logger.js"
 import { patch } from "./patches.js"
@@ -67,7 +68,7 @@ export async function init() {
   try {
     config = await read()
   } catch (err) {
-    console.warn(
+    log(
       "Invalid SolarWinds APM configuration, application will not be instrumented.",
     )
     printError(err)

--- a/packages/solarwinds-apm/src/logger.ts
+++ b/packages/solarwinds-apm/src/logger.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/logger.ts
+++ b/packages/solarwinds-apm/src/logger.ts
@@ -20,6 +20,8 @@ import util from "node:util"
 import { diag, type DiagLogFunction, type DiagLogger } from "@opentelemetry/api"
 import stringify from "json-stringify-safe"
 
+import log from "./commonjs/log.js"
+
 const COLOURS = {
   red: "\x1b[1;31m",
   yellow: "\x1b[1;33m",
@@ -35,8 +37,8 @@ export function componentLogger(component: {
 }
 
 export class Logger implements DiagLogger {
-  readonly error = Logger.makeLogger("error", "red")
-  readonly warn = Logger.makeLogger("warn", "yellow")
+  readonly error = Logger.makeLogger("error", "red", console.error)
+  readonly warn = Logger.makeLogger("warn", "yellow", console.warn)
   readonly info = Logger.makeLogger("info", "cyan")
   readonly debug = Logger.makeLogger("debug")
   readonly verbose = Logger.makeLogger("verbose")
@@ -44,6 +46,7 @@ export class Logger implements DiagLogger {
   private static makeLogger(
     level: string,
     colour?: keyof typeof COLOURS,
+    pretty: typeof console.log = console.log,
   ): DiagLogFunction {
     if (process.stdout.isTTY && process.stdout.hasColors(16)) {
       const colourCode = colour && COLOURS[colour]
@@ -66,7 +69,7 @@ export class Logger implements DiagLogger {
           line += ` ${string}`
         }
 
-        console.log(line)
+        pretty(line)
       }
     } else {
       return (message, ...args) => {
@@ -74,7 +77,7 @@ export class Logger implements DiagLogger {
           message += ` ${args.shift() as string}`
         }
 
-        console.log(stringify({ time: new Date(), level, message, args }))
+        log(stringify({ time: new Date(), level, message, args }))
       }
     }
   }

--- a/packages/solarwinds-apm/src/metadata.ts
+++ b/packages/solarwinds-apm/src/metadata.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/metrics/runtime.ts
+++ b/packages/solarwinds-apm/src/metrics/runtime.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/patches.ts
+++ b/packages/solarwinds-apm/src/patches.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/processing/parent-span.ts
+++ b/packages/solarwinds-apm/src/processing/parent-span.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/processing/response-time.ts
+++ b/packages/solarwinds-apm/src/processing/response-time.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/processing/transaction-name.ts
+++ b/packages/solarwinds-apm/src/processing/transaction-name.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/propagation/headers.ts
+++ b/packages/solarwinds-apm/src/propagation/headers.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/propagation/trace-context.ts
+++ b/packages/solarwinds-apm/src/propagation/trace-context.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/sampling/http.ts
+++ b/packages/solarwinds-apm/src/sampling/http.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/sampling/http.ts
+++ b/packages/solarwinds-apm/src/sampling/http.ts
@@ -92,9 +92,10 @@ export class HttpSampler extends Sampler {
     }
   }
 
-  /** Resets last memorised warning */
-  #resetWarn() {
+  /** Resets last memorised warning and backoff */
+  #reset() {
     this.#lastWarningMessage = undefined
+    this.#backoff.reset()
   }
 
   /** Retries the request after an exponential backoff timeout */
@@ -147,7 +148,7 @@ export class HttpSampler extends Sampler {
           this.#retry()
           return
         }
-        this.#resetWarn()
+        this.#reset()
 
         // this is pretty arbitrary but the goal is to update the settings
         // before the previous ones expire with some time to spare

--- a/packages/solarwinds-apm/src/sampling/json.ts
+++ b/packages/solarwinds-apm/src/sampling/json.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/sampling/json.ts
+++ b/packages/solarwinds-apm/src/sampling/json.ts
@@ -73,8 +73,6 @@ export class JsonSampler extends Sampler {
     const parsed = this.updateSettings(unparsed[0])
     if (parsed) {
       this.#expiry = (parsed.timestamp + parsed.ttl) * 1000
-    } else {
-      this.logger.debug("invalid settings file", unparsed)
     }
   }
 }

--- a/packages/solarwinds-apm/src/sampling/sampler.ts
+++ b/packages/solarwinds-apm/src/sampling/sampler.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/semattrs.old.ts
+++ b/packages/solarwinds-apm/src/semattrs.old.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/src/storage.ts
+++ b/packages/solarwinds-apm/src/storage.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/appoptics/exporters/metrics.test.ts
+++ b/packages/solarwinds-apm/test/appoptics/exporters/metrics.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/appoptics/reporter.test.ts
+++ b/packages/solarwinds-apm/test/appoptics/reporter.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/appoptics/sampler.test.ts
+++ b/packages/solarwinds-apm/test/appoptics/sampler.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/backoff.test.ts
+++ b/packages/solarwinds-apm/test/backoff.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/config.test.ts
+++ b/packages/solarwinds-apm/test/config.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/configs/commonjs.cjs
+++ b/packages/solarwinds-apm/test/configs/commonjs.cjs
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/configs/transaction-settings.js
+++ b/packages/solarwinds-apm/test/configs/transaction-settings.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/exporters/metrics.test.ts
+++ b/packages/solarwinds-apm/test/exporters/metrics.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/patches.test.ts
+++ b/packages/solarwinds-apm/test/patches.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/processing/parent-span.test.ts
+++ b/packages/solarwinds-apm/test/processing/parent-span.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/processing/response-time.test.ts
+++ b/packages/solarwinds-apm/test/processing/response-time.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/processing/transaction-name.test.ts
+++ b/packages/solarwinds-apm/test/processing/transaction-name.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/propagation/headers.test.ts
+++ b/packages/solarwinds-apm/test/propagation/headers.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/propagation/trace-context.test.ts
+++ b/packages/solarwinds-apm/test/propagation/trace-context.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/sampling/http.test.ts
+++ b/packages/solarwinds-apm/test/sampling/http.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/sampling/json.test.ts
+++ b/packages/solarwinds-apm/test/sampling/json.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/sampling/sampler.test.ts
+++ b/packages/solarwinds-apm/test/sampling/sampler.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/solarwinds-apm/test/storage.test.ts
+++ b/packages/solarwinds-apm/test/storage.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/test/eslint.config.js
+++ b/packages/test/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/test/src/bin.ts
+++ b/packages/test/src/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/test/src/plugin.ts
+++ b/packages/test/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/test/src/ts-node/import.mts
+++ b/packages/test/src/ts-node/import.mts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/test/src/ts-node/loader.mts
+++ b/packages/test/src/ts-node/loader.mts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/diagnostic.js
+++ b/scripts/diagnostic.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/docker.js
+++ b/scripts/docker.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/env.js
+++ b/scripts/env.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/eslint.config.js
+++ b/scripts/eslint.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/example.js
+++ b/scripts/example.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/lambda.js
+++ b/scripts/lambda.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/scan.js
+++ b/scripts/scan.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/testing.js
+++ b/scripts/testing.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/udpdump.js
+++ b/scripts/udpdump.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/vscode.js
+++ b/scripts/vscode.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2024 SolarWinds Worldwide, LLC.
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
The options are added to prevent conflicts with some extremely cursed Node modules that depend on stdout containing only their own output. Also this includes the year 2025 copyright notice changes so I would recommend reviewing on a commit per commit basis ignoring that one :)