### PR TITLE
Remove `unref` calls that would crash in the browser

### DIFF
--- a/.yarn/versions/d5f0cc26.yml
+++ b/.yarn/versions/d5f0cc26.yml
@@ -1,0 +1,8 @@
+releases:
+  "@solarwinds-apm/module": minor
+  "@solarwinds-apm/sampling": major
+  solarwinds-apm: patch
+
+declined:
+  - "@solarwinds-apm/dependencies"
+  - "@solarwinds-apm/instrumentations"

--- a/packages/module/src/index.ts
+++ b/packages/module/src/index.ts
@@ -16,6 +16,17 @@ limitations under the License.
 
 import { env } from "node:process"
 
+/**
+ * Unrefs a Node.js reference counted object so it
+ * doesn't prevent the runtime from shutting down
+ **/
+export function unref<T extends NodeJS.RefCounted | number>(ref: T): T {
+  if (typeof ref === "object") {
+    ref.unref()
+  }
+  return ref
+}
+
 export async function load(url: string): Promise<unknown> {
   const imported = (await import(url)) as object
 

--- a/packages/sampling/package.json
+++ b/packages/sampling/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.6.1",
-    "@opentelemetry/sdk-trace-base": "~1.30.0"
+    "@opentelemetry/sdk-trace-base": "~1.30.0",
+    "@solarwinds-apm/module": "workspace:^"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0"

--- a/packages/sampling/src/sampler.ts
+++ b/packages/sampling/src/sampler.ts
@@ -111,8 +111,6 @@ export abstract class OboeSampler implements Sampler {
   constructor(protected readonly logger: DiagLogger) {
     for (const bucket of Object.values(this.#buckets)) {
       bucket.start()
-      // unref the bucket so that it doesn't prevent the process from exiting
-      bucket.unref()
     }
   }
 

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -28,8 +28,7 @@ import {
   type ResourceDetectorConfigMap,
   type Set,
 } from "@solarwinds-apm/instrumentations"
-import { IS_SERVERLESS } from "@solarwinds-apm/module"
-import { ref } from "@solarwinds-apm/module"
+import { IS_SERVERLESS, load } from "@solarwinds-apm/module"
 import { z, ZodError, ZodIssueCode } from "zod"
 
 import log from "./commonjs/log.js"
@@ -252,7 +251,7 @@ export async function read(): Promise<Configuration> {
         const read: unknown =
           path.extname(option) === ".json"
             ? JSON.parse(await fs.readFile(option, { encoding: "utf-8" }))
-            : await ref(pathToFileURL(option).href)
+            : await load(pathToFileURL(option).href)
 
         if (typeof read !== "object" || read === null) {
           throw new Error(`Expected config object, got ${typeof read}.`)

--- a/packages/solarwinds-apm/src/config.ts
+++ b/packages/solarwinds-apm/src/config.ts
@@ -29,7 +29,7 @@ import {
   type Set,
 } from "@solarwinds-apm/instrumentations"
 import { IS_SERVERLESS } from "@solarwinds-apm/module"
-import { load } from "@solarwinds-apm/module"
+import { ref } from "@solarwinds-apm/module"
 import { z, ZodError, ZodIssueCode } from "zod"
 
 import log from "./commonjs/log.js"
@@ -252,7 +252,7 @@ export async function read(): Promise<Configuration> {
         const read: unknown =
           path.extname(option) === ".json"
             ? JSON.parse(await fs.readFile(option, { encoding: "utf-8" }))
-            : await load(pathToFileURL(option).href)
+            : await ref(pathToFileURL(option).href)
 
         if (typeof read !== "object" || read === null) {
           throw new Error(`Expected config object, got ${typeof read}.`)

--- a/packages/solarwinds-apm/src/processing/transaction-name.ts
+++ b/packages/solarwinds-apm/src/processing/transaction-name.ts
@@ -24,6 +24,7 @@ import {
   ATTR_HTTP_ROUTE,
   ATTR_URL_PATH,
 } from "@opentelemetry/semantic-conventions"
+import { unref } from "@solarwinds-apm/module"
 
 import { type Configuration } from "../config.js"
 import { componentLogger } from "../logger.js"
@@ -154,10 +155,9 @@ export class TransactionNamePool {
     }
 
     if (existing !== undefined || this.#pool.size < this.#max) {
-      const timeout = setTimeout(
-        () => this.#pool.delete(name),
-        this.#ttl,
-      ).unref()
+      const timeout = unref(
+        setTimeout(() => this.#pool.delete(name), this.#ttl),
+      )
       this.#pool.set(name, timeout)
       return name
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1901,6 +1901,7 @@ __metadata:
     "@opentelemetry/sdk-metrics": "npm:~1.30.0"
     "@opentelemetry/sdk-trace-base": "npm:~1.30.0"
     "@solarwinds-apm/eslint-config": "workspace:^"
+    "@solarwinds-apm/module": "workspace:^"
     "@solarwinds-apm/test": "workspace:^"
     "@types/node": "npm:^18.19.0"
     eslint: "npm:^9.12.0"


### PR DESCRIPTION
When targettng Node.js, we need to `unref` timers since they are reference counted objects that prevent the runtime from shutting down while they exist. However timers do not have an `unref` method in browsers and attempting to call it there would crash. Instead we make sure that the method exists before calling it (the logic for this is extracted to a utility function).