### PR TITLE
Detect k8s metadata on EKS and GCP

### DIFF
--- a/.yarn/versions/39bf73da.yml
+++ b/.yarn/versions/39bf73da.yml
@@ -1,0 +1,3 @@
+releases:
+  "@solarwinds-apm/instrumentations": minor
+  solarwinds-apm: minor

--- a/packages/instrumentations/COMPATIBILITY.md
+++ b/packages/instrumentations/COMPATIBILITY.md
@@ -4,7 +4,7 @@
 | --------------------------- | ------------------ | ------------------------------------------------- |
 | `@aws-sdk/middleware-stack` | `>=3.1.0 <4.0.0`   | `@opentelemetry/instrumentation-aws-sdk`          |
 | `@aws-sdk/smithy-client`    | `>=3.1.0 <4.0.0`   | `@opentelemetry/instrumentation-aws-sdk`          |
-| `@cucumber/cucumber`        | `>=8.0.0 <11.0.0`  | `@opentelemetry/instrumentation-cucumber`         |
+| `@cucumber/cucumber`        | `>=8.0.0 <12.0.0`  | `@opentelemetry/instrumentation-cucumber`         |
 | `@grpc/grpc-js`             | `>=1.0.0 <2.0.0`   | `@opentelemetry/instrumentation-grpc`             |
 | `@hapi/hapi`                | `>=17.0.0 <22.0.0` | `@opentelemetry/instrumentation-hapi`             |
 | `@nestjs/core`              | `>=4.0.0 <11.0.0`  | `@opentelemetry/instrumentation-nestjs-core`      |

--- a/packages/instrumentations/package.json
+++ b/packages/instrumentations/package.json
@@ -84,6 +84,7 @@
     "@opentelemetry/resource-detector-aws": "^1.3.1",
     "@opentelemetry/resource-detector-azure": "^0.6.0",
     "@opentelemetry/resource-detector-container": "^0.6.0",
+    "@opentelemetry/resource-detector-gcp": "^0.33.0",
     "@opentelemetry/resources": "~1.30.0",
     "@opentelemetry/semantic-conventions": "~1.30.0",
     "@opentelemetry/winston-transport": "^0.10.0",

--- a/packages/instrumentations/src/index.ts
+++ b/packages/instrumentations/src/index.ts
@@ -162,11 +162,22 @@ const CORE_RESOURCE_DETECTORS = {
     "processDetectorSync",
     "serviceInstanceIdDetectorSync",
   ],
+  "@opentelemetry/resource-detector-aws": ["awsLambdaDetectorSync"],
 } as const
 const RESOURCE_DETECTORS = {
-  "@opentelemetry/resource-detector-aws": ["awsEc2Detector"],
-  "@opentelemetry/resource-detector-azure": ["azureAppServiceDetector"],
   "@opentelemetry/resource-detector-container": ["containerDetector"],
+  "@opentelemetry/resource-detector-aws": [
+    "awsBeanstalkDetectorSync",
+    "awsEc2DetectorSync",
+    "awsEcsDetectorSync",
+    "awsEksDetectorSync",
+  ],
+  "@opentelemetry/resource-detector-azure": [
+    "azureAppServiceDetector",
+    "azureFunctionsDetector",
+    "azureVmDetector",
+  ],
+  "@opentelemetry/resource-detector-gcp": ["gcpResourceDetector"],
   "./resource-detector-uams": ["uamsDetector"],
 } as const
 

--- a/packages/instrumentations/src/index.ts
+++ b/packages/instrumentations/src/index.ts
@@ -177,7 +177,7 @@ const RESOURCE_DETECTORS = {
     "azureFunctionsDetector",
     "azureVmDetector",
   ],
-  "@opentelemetry/resource-detector-gcp": ["gcpResourceDetector"],
+  "@opentelemetry/resource-detector-gcp": ["gcpDetector"],
   "./resource-detector-uams": ["uamsDetector"],
 } as const
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,6 +1573,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/resource-detector-gcp@npm:^0.33.0":
+  version: 0.33.0
+  resolution: "@opentelemetry/resource-detector-gcp@npm:0.33.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.0.0"
+    "@opentelemetry/resources": "npm:^1.10.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.27.0"
+    gcp-metadata: "npm:^6.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 10c0/d3176b28da733ed2cf077702501f4d6ad7069320e7868ecbe3b0764804114193f6e13b2e40dd32a5a11eb01c424ca8e9ddf9c50b5a696b0ebfb8590c22e5adf0
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/resources@npm:1.30.1, @opentelemetry/resources@npm:^1.10.0, @opentelemetry/resources@npm:^1.10.1, @opentelemetry/resources@npm:~1.30.0":
   version: 1.30.1
   resolution: "@opentelemetry/resources@npm:1.30.1"
@@ -2113,6 +2127,7 @@ __metadata:
     "@opentelemetry/resource-detector-aws": "npm:^1.3.1"
     "@opentelemetry/resource-detector-azure": "npm:^0.6.0"
     "@opentelemetry/resource-detector-container": "npm:^0.6.0"
+    "@opentelemetry/resource-detector-gcp": "npm:^0.33.0"
     "@opentelemetry/resources": "npm:~1.30.0"
     "@opentelemetry/semantic-conventions": "npm:~1.30.0"
     "@opentelemetry/winston-transport": "npm:^0.10.0"
@@ -3016,6 +3031,13 @@ __metadata:
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^9.0.0":
+  version: 9.1.2
+  resolution: "bignumber.js@npm:9.1.2"
+  checksum: 10c0/e17786545433f3110b868725c449fa9625366a6e675cd70eb39b60938d6adbd0158cb4b3ad4f306ce817165d37e63f4aa3098ba4110db1d9a3b9f66abfbaf10d
   languageName: node
   linkType: hard
 
@@ -4472,6 +4494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extend@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
+  languageName: node
+  linkType: hard
+
 "fast-decode-uri-component@npm:^1.0.1":
   version: 1.0.1
   resolution: "fast-decode-uri-component@npm:1.0.1"
@@ -4818,6 +4847,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gaxios@npm:^6.1.1":
+  version: 6.7.1
+  resolution: "gaxios@npm:6.7.1"
+  dependencies:
+    extend: "npm:^3.0.2"
+    https-proxy-agent: "npm:^7.0.1"
+    is-stream: "npm:^2.0.0"
+    node-fetch: "npm:^2.6.9"
+    uuid: "npm:^9.0.1"
+  checksum: 10c0/53e92088470661c5bc493a1de29d05aff58b1f0009ec5e7903f730f892c3642a93e264e61904383741ccbab1ce6e519f12a985bba91e13527678b32ee6d7d3fd
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "gcp-metadata@npm:6.1.1"
+  dependencies:
+    gaxios: "npm:^6.1.1"
+    google-logging-utils: "npm:^0.0.2"
+    json-bigint: "npm:^1.0.0"
+  checksum: 10c0/71f6ad4800aa622c246ceec3955014c0c78cdcfe025971f9558b9379f4019f5e65772763428ee8c3244fa81b8631977316eaa71a823493f82e5c44d7259ffac8
+  languageName: node
+  linkType: hard
+
 "generate-function@npm:^2.3.1":
   version: 2.3.1
   resolution: "generate-function@npm:2.3.1"
@@ -4951,6 +5004,13 @@ __metadata:
     merge2: "npm:^1.4.1"
     slash: "npm:^3.0.0"
   checksum: 10c0/b39511b4afe4bd8a7aead3a27c4ade2b9968649abab0a6c28b1a90141b96ca68ca5db1302f7c7bd29eab66bf51e13916b8e0a3d0ac08f75e1e84a39b35691189
+  languageName: node
+  linkType: hard
+
+"google-logging-utils@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "google-logging-utils@npm:0.0.2"
+  checksum: 10c0/9a4bbd470dd101c77405e450fffca8592d1d7114f245a121288d04a957aca08c9dea2dd1a871effe71e41540d1bb0494731a0b0f6fea4358e77f06645e4268c1
   languageName: node
   linkType: hard
 
@@ -5600,6 +5660,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-bigint@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-bigint@npm:1.0.0"
+  dependencies:
+    bignumber.js: "npm:^9.0.0"
+  checksum: 10c0/e3f34e43be3284b573ea150a3890c92f06d54d8ded72894556357946aeed9877fd795f62f37fe16509af189fd314ab1104d0fd0f163746ad231b9f378f5b33f4
+  languageName: node
+  linkType: hard
+
 "json-buffer@npm:3.0.1":
   version: 3.0.1
   resolution: "json-buffer@npm:3.0.1"
@@ -6238,6 +6307,20 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/0ed4206cb68921b33fc637c6f7ffcb91fcde85aea88ea60fadb7b0537bf177226a5600584eac9db2aff93600041d42796fb20576b3299b9be6ff7539592b2180
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.9":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
   languageName: node
   linkType: hard
 
@@ -8082,6 +8165,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
 "tree-kill@npm:^1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
@@ -8419,6 +8509,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
+  languageName: node
+  linkType: hard
+
 "v8-compile-cache-lib@npm:^3.0.1":
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
@@ -8462,6 +8561,23 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10c0/5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This enables some extra contrib detectors by default to detect Kubernetes metadata on AWS EKS and GPC. More generic approach based on the oboe code will follow.