### PR TITLE
Only patch instrumented modules

### DIFF
--- a/.yarn/versions/4fad2c7d.yml
+++ b/.yarn/versions/4fad2c7d.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: patch

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -83,6 +83,7 @@
     "@solarwinds-apm/instrumentations": "workspace:^",
     "@solarwinds-apm/module": "workspace:^",
     "@solarwinds-apm/sampling": "workspace:^",
+    "import-in-the-middle": "^1.11.0",
     "json-stringify-safe": "^5.0.1",
     "node-releases": "^2.0.18",
     "semver": "^7.6.3",

--- a/packages/solarwinds-apm/src/hooks.js
+++ b/packages/solarwinds-apm/src/hooks.js
@@ -14,4 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export * from "@opentelemetry/instrumentation/hook.mjs"
+import { load as otel } from "@opentelemetry/instrumentation/hook.mjs"
+import { load as iitm } from "import-in-the-middle/hook.mjs"
+
+if (otel !== iitm) {
+  import("./commonjs/log.js").then(({ default: log }) =>
+    log(
+      "Duplicate versions of import-in-the-middle were detected.",
+      "The application may not be instrumented.",
+      "Please run 'npm update import-in-the-middle',",
+      "or the equivalent for your package manager.",
+    ),
+  )
+}
+
+export * from "import-in-the-middle/hook.mjs"

--- a/packages/solarwinds-apm/src/index.ts
+++ b/packages/solarwinds-apm/src/index.ts
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { register } from "module"
+import { register } from "node:module"
+
+import { createAddHookMessageChannel } from "import-in-the-middle"
 
 import { INIT } from "./commonjs/flags.js"
 import log from "./commonjs/log.js"
@@ -34,8 +36,11 @@ if (!Reflect.has(globalThis, INIT)) {
       writable: true,
     })
 
-    register("./hooks.js", import.meta.url)
+    const { registerOptions, waitForAllMessagesAcknowledged } =
+      createAddHookMessageChannel()
+    register("./hooks.js", import.meta.url, registerOptions)
     await init()
+    await waitForAllMessagesAcknowledged()
 
     Reflect.defineProperty(globalThis, INIT, {
       value: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5249,15 +5249,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-in-the-middle@npm:^1.8.1":
-  version: 1.13.0
-  resolution: "import-in-the-middle@npm:1.13.0"
+"import-in-the-middle@npm:^1.11.0, import-in-the-middle@npm:^1.8.1":
+  version: 1.13.1
+  resolution: "import-in-the-middle@npm:1.13.1"
   dependencies:
     acorn: "npm:^8.14.0"
     acorn-import-attributes: "npm:^1.9.5"
     cjs-module-lexer: "npm:^1.2.2"
     module-details-from-path: "npm:^1.0.3"
-  checksum: 10c0/f84146bf5eabf5a9cf2269a65413487be26ba21cb3cd33ffb8e59e0f94d775a624a4d2c77ef3dc06f89f7ce5265c3ec2e93546a73b70ce9aac6a6932be6e0aba
+  checksum: 10c0/4ef05a924c37ff718dd08654927c90d470d92fd9425d646b0d423aaddc89655848debd14761bcb6efa4f57870d63ff38109bab31ca8a1d9d5df2e7d84d2649cf
   languageName: node
   linkType: hard
 
@@ -7821,6 +7821,7 @@ __metadata:
     caniuse-lite: "npm:^1.0"
     esbuild: "npm:^0.25.0"
     eslint: "npm:^9.12.0"
+    import-in-the-middle: "npm:^1.11.0"
     json-stringify-safe: "npm:^5.0.1"
     node-releases: "npm:^2.0.18"
     prettier: "npm:^3.3.3"


### PR DESCRIPTION
This uses a [new feature](https://github.com/nodejs/import-in-the-middle/tree/import-in-the-middle-v1.11.0?tab=readme-ov-file#only-intercepting-hooked-modules) from `import-in-the-middle` to only patch instrumented modules, which fixes issues with Nuxt and potential future issues with other unpatched modules.