### PR TITLE
Don't disable logging instrumentations when `insertTraceContextIntoLogs` is `false`

### DIFF
--- a/.yarn/versions/f6051174.yml
+++ b/.yarn/versions/f6051174.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: patch

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -134,10 +134,14 @@ async function initInstrumentations(config: Configuration, logger: DiagLogger) {
   logger.debug("initialising instrumentations")
 
   const provided = await getInstrumentations(
-    patch(config.instrumentations.configs, {
-      ...config,
-      responsePropagator: new ResponseHeadersPropagator(),
-    }),
+    patch(
+      config.instrumentations.configs,
+      {
+        ...config,
+        responsePropagator: new ResponseHeadersPropagator(),
+      },
+      logger,
+    ),
     config.instrumentations.set,
   )
   const extra = config.instrumentations.extra

--- a/packages/solarwinds-apm/test/patches.test.ts
+++ b/packages/solarwinds-apm/test/patches.test.ts
@@ -22,7 +22,7 @@ import {
   type TextMapPropagator,
   type TextMapSetter,
 } from "@opentelemetry/api"
-import { beforeEach, describe, expect, it } from "@solarwinds-apm/test"
+import { afterEach, describe, expect, it } from "@solarwinds-apm/test"
 
 import { type Options, patch } from "../src/patches.js"
 
@@ -105,7 +105,7 @@ describe("patch", () => {
   })
 
   describe("@opentelemetry/instrumentation-aws-lambda", () => {
-    beforeEach(() => {
+    afterEach(() => {
       Reflect.deleteProperty(process.env, "AWS_LAMBDA_FUNCTION_NAME")
     })
 
@@ -161,7 +161,7 @@ describe("patch", () => {
   })
 
   describe("@opentelemetry/instrumentation-aws-sdk", () => {
-    beforeEach(() => {
+    afterEach(() => {
       Reflect.deleteProperty(process.env, "AWS_LAMBDA_FUNCTION_NAME")
     })
 

--- a/packages/solarwinds-apm/test/patches.test.ts
+++ b/packages/solarwinds-apm/test/patches.test.ts
@@ -14,22 +14,50 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type InstrumentationConfigMap } from "@solarwinds-apm/instrumentations"
-import { describe, expect, it } from "@solarwinds-apm/test"
+import { type IncomingMessage, type ServerResponse } from "node:http"
+
+import {
+  type Context,
+  diag,
+  type TextMapPropagator,
+  type TextMapSetter,
+} from "@opentelemetry/api"
+import { beforeEach, describe, expect, it } from "@solarwinds-apm/test"
 
 import { type Options, patch } from "../src/patches.js"
 
+class TestResponsePropagator implements TextMapPropagator<unknown> {
+  inject(
+    _context: Context,
+    carrier: unknown,
+    setter: TextMapSetter<unknown>,
+  ): void {
+    setter.set(carrier, "X-Test", "hello")
+  }
+  extract(context: Context): Context {
+    return context
+  }
+
+  fields(): string[] {
+    return ["X-Test"]
+  }
+}
+
 describe("patch", () => {
-  const options: Options = {
-    insertTraceContextIntoLogs: true,
+  const options = {
+    service: "service",
+    insertTraceContextIntoLogs: false,
     insertTraceContextIntoQueries: false,
     exportLogsEnabled: false,
-  } as Options
+    responsePropagator: new TestResponsePropagator(),
+  } as unknown as Options
 
   it("sets proper defaults", () => {
-    const configs: InstrumentationConfigMap = {}
+    const configs = patch({}, options, diag)
 
-    patch(configs, options)
+    expect(configs["@fastify/otel"]).to.deep.equal({
+      registerOnInitialization: true,
+    })
     expect(configs["@opentelemetry/instrumentation-aws-lambda"]).to.deep.equal({
       enabled: false,
     })
@@ -44,79 +72,458 @@ describe("patch", () => {
       requireParentSpan: true,
       addSqlCommenterCommentToQueries: false,
     })
-
     expect(configs["@opentelemetry/instrumentation-bunyan"]).to.deep.include({
-      enabled: true,
+      disableLogCorrelation: true,
       disableLogSending: true,
     })
     expect(configs["@opentelemetry/instrumentation-pino"]).to.deep.include({
-      enabled: true,
+      disableLogCorrelation: true,
       disableLogSending: true,
     })
     expect(configs["@opentelemetry/instrumentation-winston"]).to.deep.include({
-      enabled: true,
+      disableLogCorrelation: true,
       disableLogSending: true,
     })
   })
 
-  it("respects user values", () => {
-    const configs: InstrumentationConfigMap = {
-      "@opentelemetry/instrumentation-aws-lambda": {
+  describe("@fastify/otel", () => {
+    it("respects user values", () => {
+      const configs = patch(
+        {
+          "@fastify/otel": {
+            registerOnInitialization: false,
+          },
+        },
+        options,
+        diag,
+      )
+
+      expect(configs["@fastify/otel"]).to.deep.equal({
+        registerOnInitialization: false,
+      })
+    })
+  })
+
+  describe("@opentelemetry/instrumentation-aws-lambda", () => {
+    beforeEach(() => {
+      Reflect.deleteProperty(process.env, "AWS_LAMBDA_FUNCTION_NAME")
+    })
+
+    it("is enabled in lambda environments", () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "lambda"
+
+      const configs = patch({}, options, diag)
+
+      expect(
+        configs["@opentelemetry/instrumentation-aws-lambda"],
+      ).to.deep.equal({
         enabled: true,
-      },
-      "@opentelemetry/instrumentation-aws-sdk": {
+      })
+    })
+
+    it("respects user values outside lambda environments", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-aws-lambda": {
+            enabled: true,
+          },
+        },
+        options,
+        diag,
+      )
+
+      expect(
+        configs["@opentelemetry/instrumentation-aws-lambda"],
+      ).to.deep.equal({
+        enabled: true,
+      })
+    })
+
+    it("respects user values in lambda environments", () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "lambda"
+
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-aws-lambda": {
+            enabled: false,
+          },
+        },
+        options,
+        diag,
+      )
+
+      expect(
+        configs["@opentelemetry/instrumentation-aws-lambda"],
+      ).to.deep.equal({
         enabled: false,
-      },
-      "@opentelemetry/instrumentation-fs": {
-        requireParentSpan: false,
-      },
-      "@opentelemetry/instrumentation-mysql2": {
+      })
+    })
+  })
+
+  describe("@opentelemetry/instrumentation-aws-sdk", () => {
+    beforeEach(() => {
+      Reflect.deleteProperty(process.env, "AWS_LAMBDA_FUNCTION_NAME")
+    })
+
+    it("is enabled in lambda environments", () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "lambda"
+
+      const configs = patch({}, options, diag)
+
+      expect(configs["@opentelemetry/instrumentation-aws-sdk"]).to.deep.equal({
+        enabled: true,
+      })
+    })
+
+    it("respects user values in lambda environments", () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "lambda"
+
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-aws-sdk": {
+            enabled: false,
+          },
+        },
+        options,
+        diag,
+      )
+
+      expect(configs["@opentelemetry/instrumentation-aws-sdk"]).to.deep.equal({
+        enabled: false,
+      })
+    })
+  })
+
+  describe("@opentelemetry/instrumentation-http", () => {
+    it("injects headers in response hook", () => {
+      const configs = patch({}, options, diag)
+      const response = {
+        headers: {} as Record<string, string>,
+        hasHeader(name: string) {
+          return name in this.headers
+        },
+        setHeader(name: string, value: string) {
+          this.headers[name] = value
+        },
+      }
+      configs["@opentelemetry/instrumentation-http"]!.responseHook!(
+        null!,
+        response as unknown as ServerResponse,
+      )
+
+      expect(response.headers).to.deep.equal({ "X-Test": "hello" })
+    })
+
+    it("doesn't inject headers for incoming responses in response hook", () => {
+      const configs = patch({}, options, diag)
+      const response = {
+        headers: {} as Record<string, string>,
+      }
+      configs["@opentelemetry/instrumentation-http"]!.responseHook!(
+        null!,
+        response as IncomingMessage,
+      )
+
+      expect(response.headers).to.deep.equal({})
+    })
+
+    it("doesn't override headers in response hook", () => {
+      const configs = patch({}, options, diag)
+      const response = {
+        headers: {
+          "X-Test": "goodbye",
+        } as Record<string, string>,
+        hasHeader(name: string) {
+          return name in this.headers
+        },
+        setHeader(name: string, value: string) {
+          this.headers[name] = value
+        },
+      }
+      configs["@opentelemetry/instrumentation-http"]!.responseHook!(
+        null!,
+        response as unknown as ServerResponse,
+      )
+
+      expect(response.headers).to.deep.equal({ "X-Test": "goodbye" })
+    })
+
+    it("calls custom response hook in response hook", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-http": {
+            responseHook(_span, response) {
+              ;(response as ServerResponse).setHeader("X-Custom", "http")
+            },
+          },
+        },
+        options,
+        diag,
+      )
+      const response = {
+        headers: {} as Record<string, string>,
+        hasHeader(name: string) {
+          return name in this.headers
+        },
+        setHeader(name: string, value: string) {
+          this.headers[name] = value
+        },
+      }
+      configs["@opentelemetry/instrumentation-http"]!.responseHook!(
+        null!,
+        response as unknown as ServerResponse,
+      )
+
+      expect(response.headers).to.deep.equal({
+        "X-Test": "hello",
+        "X-Custom": "http",
+      })
+    })
+  })
+
+  describe("@opentelemetry/instrumentation-mysql2", () => {
+    it("respects custom config", () => {
+      const configs = patch(
+        {},
+        { ...options, insertTraceContextIntoQueries: true },
+        diag,
+      )
+
+      expect(configs["@opentelemetry/instrumentation-mysql2"]).to.deep.equal({
         addSqlCommenterCommentToQueries: true,
-      },
-      "@opentelemetry/instrumentation-pg": {
+      })
+    })
+
+    it("respects user values over defaults", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-mysql2": {
+            addSqlCommenterCommentToQueries: true,
+          },
+        },
+        options,
+        diag,
+      )
+
+      expect(configs["@opentelemetry/instrumentation-mysql2"]).to.deep.equal({
+        addSqlCommenterCommentToQueries: true,
+      })
+    })
+
+    it("respects user values over custom config", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-mysql2": {
+            addSqlCommenterCommentToQueries: false,
+          },
+        },
+        { ...options, insertTraceContextIntoQueries: true },
+        diag,
+      )
+
+      expect(configs["@opentelemetry/instrumentation-mysql2"]).to.deep.equal({
+        addSqlCommenterCommentToQueries: false,
+      })
+    })
+  })
+
+  describe("@opentelemetry/instrumentation-pg", () => {
+    it("respects custom config", () => {
+      const configs = patch(
+        {},
+        { ...options, insertTraceContextIntoQueries: true },
+        diag,
+      )
+
+      expect(configs["@opentelemetry/instrumentation-pg"]).to.deep.equal({
+        requireParentSpan: true,
+        addSqlCommenterCommentToQueries: true,
+      })
+    })
+
+    it("respects user values over defaults", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-pg": {
+            requireParentSpan: false,
+            addSqlCommenterCommentToQueries: true,
+          },
+        },
+        options,
+        diag,
+      )
+
+      expect(configs["@opentelemetry/instrumentation-pg"]).to.deep.equal({
         requireParentSpan: false,
         addSqlCommenterCommentToQueries: true,
-      },
-
-      "@opentelemetry/instrumentation-bunyan": {
-        enabled: false,
-        disableLogSending: false,
-      },
-      "@opentelemetry/instrumentation-winston": {
-        enabled: false,
-        disableLogSending: false,
-      },
-    }
-
-    patch(configs, options)
-    expect(configs["@opentelemetry/instrumentation-aws-lambda"]).to.deep.equal({
-      enabled: true,
-    })
-    expect(configs["@opentelemetry/instrumentation-aws-sdk"]).to.deep.equal({
-      enabled: false,
-    })
-    expect(configs["@opentelemetry/instrumentation-fs"]).to.deep.equal({
-      requireParentSpan: false,
-    })
-    expect(configs["@opentelemetry/instrumentation-mysql2"]).to.deep.equal({
-      addSqlCommenterCommentToQueries: true,
-    })
-    expect(configs["@opentelemetry/instrumentation-pg"]).to.deep.equal({
-      requireParentSpan: false,
-      addSqlCommenterCommentToQueries: true,
+      })
     })
 
-    expect(configs["@opentelemetry/instrumentation-bunyan"]).to.deep.include({
-      enabled: false,
-      disableLogSending: false,
+    it("respects user values over custom config", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-pg": {
+            requireParentSpan: false,
+            addSqlCommenterCommentToQueries: false,
+          },
+        },
+        { ...options, insertTraceContextIntoQueries: true },
+        diag,
+      )
+
+      expect(configs["@opentelemetry/instrumentation-pg"]).to.deep.equal({
+        requireParentSpan: false,
+        addSqlCommenterCommentToQueries: false,
+      })
     })
-    expect(configs["@opentelemetry/instrumentation-pino"]).to.deep.include({
-      enabled: true,
-      disableLogSending: true,
+  })
+
+  describe("logging instrumentations", () => {
+    const INSTRUMENTATIONS = [
+      "@opentelemetry/instrumentation-bunyan",
+      "@opentelemetry/instrumentation-pino",
+      "@opentelemetry/instrumentation-winston",
+    ] as const
+
+    it("respect custom config", () => {
+      const configs = patch(
+        {},
+        {
+          ...options,
+          insertTraceContextIntoLogs: true,
+          exportLogsEnabled: true,
+        },
+        diag,
+      )
+
+      for (const i of INSTRUMENTATIONS) {
+        expect(configs[i]).to.deep.include({
+          disableLogCorrelation: false,
+          disableLogSending: false,
+        })
+      }
     })
-    expect(configs["@opentelemetry/instrumentation-winston"]).to.deep.include({
-      enabled: false,
-      disableLogSending: false,
+
+    it("respect user values over defaults", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-bunyan": {
+            disableLogCorrelation: false,
+            disableLogSending: false,
+          },
+          "@opentelemetry/instrumentation-pino": {
+            disableLogCorrelation: false,
+            disableLogSending: false,
+          },
+          "@opentelemetry/instrumentation-winston": {
+            disableLogCorrelation: false,
+            disableLogSending: false,
+          },
+        },
+        options,
+        diag,
+      )
+
+      for (const i of INSTRUMENTATIONS) {
+        expect(configs[i]).to.deep.include({
+          disableLogCorrelation: false,
+          disableLogSending: false,
+        })
+      }
+    })
+
+    it("respect user values over custom config", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-bunyan": {
+            disableLogCorrelation: true,
+            disableLogSending: true,
+          },
+          "@opentelemetry/instrumentation-pino": {
+            disableLogCorrelation: true,
+            disableLogSending: true,
+          },
+          "@opentelemetry/instrumentation-winston": {
+            disableLogCorrelation: true,
+            disableLogSending: true,
+          },
+        },
+        {
+          ...options,
+          insertTraceContextIntoLogs: true,
+          exportLogsEnabled: true,
+        },
+        diag,
+      )
+
+      for (const i of INSTRUMENTATIONS) {
+        expect(configs[i]).to.deep.include({
+          disableLogCorrelation: true,
+          disableLogSending: true,
+        })
+      }
+    })
+
+    it("add service name in log hook", () => {
+      const configs = patch({}, options, diag)
+
+      for (const i of INSTRUMENTATIONS) {
+        const record: Record<string, unknown> = {}
+        configs[i]!.logHook!(null!, record)
+
+        expect(record).to.deep.equal({
+          "resource.service.name": "service",
+        })
+      }
+    })
+
+    it("don't override service name in log hook", () => {
+      const configs = patch({}, options, diag)
+
+      for (const i of INSTRUMENTATIONS) {
+        const record: Record<string, unknown> = {
+          "resource.service.name": "evil service",
+        }
+        configs[i]!.logHook!(null!, record)
+
+        expect(record).to.deep.equal({
+          "resource.service.name": "evil service",
+        })
+      }
+    })
+
+    it("calls custom log hook in log hook", () => {
+      const configs = patch(
+        {
+          "@opentelemetry/instrumentation-bunyan": {
+            logHook(_span, record) {
+              record.instrumentation = "@opentelemetry/instrumentation-bunyan"
+            },
+          },
+          "@opentelemetry/instrumentation-pino": {
+            logHook(_span, record) {
+              record.instrumentation = "@opentelemetry/instrumentation-pino"
+            },
+          },
+          "@opentelemetry/instrumentation-winston": {
+            logHook(_span, record) {
+              record.instrumentation = "@opentelemetry/instrumentation-winston"
+            },
+          },
+        },
+        options,
+        diag,
+      )
+
+      for (const i of INSTRUMENTATIONS) {
+        const record: Record<string, unknown> = {}
+        configs[i]!.logHook!(null!, record)
+
+        expect(record).to.deep.equal({
+          "resource.service.name": "service",
+          instrumentation: i,
+        })
+      }
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,7 +2526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.31.0":
+"@typescript-eslint/eslint-plugin@npm:8.31.0, @typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.31.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.31.0"
   dependencies:
@@ -2547,28 +2547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.30.0"
-  dependencies:
-    "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.30.0"
-    "@typescript-eslint/type-utils": "npm:8.30.0"
-    "@typescript-eslint/utils": "npm:8.30.0"
-    "@typescript-eslint/visitor-keys": "npm:8.30.0"
-    graphemer: "npm:^1.4.0"
-    ignore: "npm:^5.3.1"
-    natural-compare: "npm:^1.4.0"
-    ts-api-utils: "npm:^2.0.1"
-  peerDependencies:
-    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/511ef849cd99de800b25a92aff49c8b4bcd01372d4a754b89ec7dfb7ddfe1f6204061aa4773591a864f28437df9993d74ef85ef5a707d73a6b1b80da6dc0cc3f
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:8.31.0":
+"@typescript-eslint/parser@npm:8.31.0, @typescript-eslint/parser@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.31.0
   resolution: "@typescript-eslint/parser@npm:8.31.0"
   dependencies:
@@ -2584,32 +2563,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/parser@npm:8.30.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.30.0"
-    "@typescript-eslint/types": "npm:8.30.0"
-    "@typescript-eslint/typescript-estree": "npm:8.30.0"
-    "@typescript-eslint/visitor-keys": "npm:8.30.0"
-    debug: "npm:^4.3.4"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/d3f13b309169e796192ad6144b0077a561c4f8437cb40b933ea85666c93ba66407b1cef2e894428f9b3d8f38de9e35072e2b5bfb8fcc4efa02b0c48fc456ce98
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/scope-manager@npm:8.30.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.30.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.30.0"
-    "@typescript-eslint/visitor-keys": "npm:8.30.0"
-  checksum: 10c0/afac28a691758724adf60d1d5128dab319cab35a56076800140dccd32ffc5b7cccd6e49d566ca5df9af1e585b07bb33e381501813bedb0cbf3a87923b315c71b
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.31.0":
   version: 8.31.0
   resolution: "@typescript-eslint/scope-manager@npm:8.31.0"
@@ -2617,21 +2570,6 @@ __metadata:
     "@typescript-eslint/types": "npm:8.31.0"
     "@typescript-eslint/visitor-keys": "npm:8.31.0"
   checksum: 10c0/eae758a24cc578fa351b8bf0c30c50de384292c0b05a58762f9b632d65a009bd5d902d806eccb6b678cc0b09686289fb4f1fd67da7f12d59ad43ff033b35cc4f
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/type-utils@npm:8.30.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/type-utils@npm:8.30.0"
-  dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.30.0"
-    "@typescript-eslint/utils": "npm:8.30.0"
-    debug: "npm:^4.3.4"
-    ts-api-utils: "npm:^2.0.1"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/a9860c71fcd3f43cd7630ba25227380b4600b045128d134324667581e76b54775253025648cb386579a4a00b546c03c65cb944e4a5e62d211d93221f24b2403f
   languageName: node
   linkType: hard
 
@@ -2650,35 +2588,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.30.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/types@npm:8.30.0"
-  checksum: 10c0/62003de2f3db7f04de8b8b59bc4cd56f04212fe2b7fbd43e5f29a6fac7d4e68bba2cf7913ffa6ae39311bf36fbb7466ba2d32defab450496cb9fe67f0ade900b
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.31.0":
   version: 8.31.0
   resolution: "@typescript-eslint/types@npm:8.31.0"
   checksum: 10c0/04130a30aac477d36d6a155399b27773457aeb9b485ef8fb56fee05725b6e36768c9fac7e4d1f073fd16988de0eb7dffc743c3f834ae907cf918cabb075e5cd8
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:8.30.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.30.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.30.0"
-    "@typescript-eslint/visitor-keys": "npm:8.30.0"
-    debug: "npm:^4.3.4"
-    fast-glob: "npm:^3.3.2"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.4"
-    semver: "npm:^7.6.0"
-    ts-api-utils: "npm:^2.0.1"
-  peerDependencies:
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/00849467a29b8c8b8b92102e80d599cc6415b3adbcafa60132b9241cd73f4d9a13f01d5ea7556836a82419200be37f2ba0f78e46ee4f839d744b5e80596ad4d2
   languageName: node
   linkType: hard
 
@@ -2700,21 +2613,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.30.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/utils@npm:8.30.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.30.0"
-    "@typescript-eslint/types": "npm:8.30.0"
-    "@typescript-eslint/typescript-estree": "npm:8.30.0"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/02f0cc42eeda10cd654d55b1f0ed2093ce1fd355bf3dbd4f1324b41a85e19940cabd4caa4d789d9eda3eca555e68f79d87db008274ae19c6ac9ff5dcb353ca20
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/utils@npm:8.31.0":
   version: 8.31.0
   resolution: "@typescript-eslint/utils@npm:8.31.0"
@@ -2727,16 +2625,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
   checksum: 10c0/1fd4f62e16a44a5be2de501f70ba4b2d64479e014370bde7bbc6de6897cf1699766a8b7be4deb9b0328e74c2b4171839336ede4e3c60fec6ac8378b623a75275
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.30.0":
-  version: 8.30.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.30.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.30.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/4d61dc9b0368c2b403ed4fd12b3d6779b7593e0615e45135180bd2a041f3310918be0053647b7fc92be6c188df9ae0459f8e312e54c41d53a42fbc198bf7f519
   languageName: node
   linkType: hard
 
@@ -6840,14 +6728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-protocol@npm:*":
-  version: 1.8.0
-  resolution: "pg-protocol@npm:1.8.0"
-  checksum: 10c0/2be784955599d84b564795952cee52cc2b8eab0be43f74fc1061506353801e282c1d52c9e0691a9b72092c1f3fde370e9b181e80fef6bb82a9b8d1618bfa91e6
-  languageName: node
-  linkType: hard
-
-"pg-protocol@npm:^1.9.5":
+"pg-protocol@npm:*, pg-protocol@npm:^1.9.5":
   version: 1.9.5
   resolution: "pg-protocol@npm:1.9.5"
   checksum: 10c0/5cb3444cf973adadd22ee9ea26bb1674f0d980ef8f9c66d426bbe67fc9cb5f0ca4a204bf7e432b3ab2ab59ac8227f4b18ab3b2e64eaed537e037e916991c7319


### PR DESCRIPTION
This caused logs to not be send even when `exportLogsEnabled` was set to `true` since the instrumentations themselves were disabled. Also added a lot of tests to cover every case of instrumentation config patching.