### PR TITLE
Fix supported Node.js versions detection

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -177,3 +177,46 @@ jobs:
         env:
           SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
           SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
+
+  supports:
+    if: github.event_name == 'pull_request'
+    needs:
+      - checks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Include versions from the most recent until the first unsupported
+        include:
+          # LTS
+          - node: 24
+            pass: true
+          - node: 22
+            pass: true
+          - node: 20
+            pass: true
+          - node: 18
+            pass: true
+          - node: 16
+            pass: false
+          # Unstable
+          - node: 23
+            pass: false
+          # Sanity check
+          - node: 8
+            pass: false
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: ./
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: node -e "require('assert').ok(${OP} require('${FILE}'))"
+        env:
+          OP: ${{ matrix.pass && '' || '!' }}
+          FILE: ./packages/solarwinds-apm/dist/commonjs/version.js

--- a/packages/solarwinds-apm/.gitignore
+++ b/packages/solarwinds-apm/.gitignore
@@ -1,2 +1,3 @@
 dist/
 src/version.ts
+src/commonjs/timestamp.js

--- a/packages/solarwinds-apm/build.js
+++ b/packages/solarwinds-apm/build.js
@@ -24,9 +24,19 @@ const version = JSON.parse(
   await fs.readFile("package.json", { encoding: "utf-8" }),
 ).version
 
-const code = `export const VERSION = "${version}"`
-const formatted = await prettier.format(code, { parser: "typescript" })
-await fs.writeFile("src/version.ts", formatted)
+await fs.writeFile(
+  "src/version.ts",
+  await prettier.format(`export const VERSION = "${version}"`, {
+    parser: "typescript",
+  }),
+)
+await fs.writeFile(
+  "src/commonjs/timestamp.js",
+  await prettier.format(
+    [`"use strict";`, `module.exports = ${Date.now()};`].join("\n"),
+    { parser: "typescript" },
+  ),
+)
 
 await fs.mkdir("dist/commonjs", { recursive: true })
 await fs.cp("src/commonjs/", "dist/commonjs/", { recursive: true, force: true })

--- a/packages/solarwinds-apm/src/commonjs/api.noop.js
+++ b/packages/solarwinds-apm/src/commonjs/api.noop.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
 Copyright 2023-2025 SolarWinds Worldwide, LLC.
 
@@ -14,5 +16,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as api from "../api.js";
-export = api;
+module.exports.setTransactionName = function setTransactionName(_name) {
+  return false;
+};
+
+module.exports.waitUntilReady = function waitUntilReady(_timeout) {
+  return Promise.resolve(false);
+};
+
+module.exports.forceFlush = function forceFlush() {
+  return Promise.resolve();
+};
+
+module.exports.VERSION = null;

--- a/packages/solarwinds-apm/src/commonjs/api.proxy.js
+++ b/packages/solarwinds-apm/src/commonjs/api.proxy.js
@@ -32,6 +32,8 @@ module.exports.forceFlush = function forceFlush() {
   return imported.then((api) => api.forceFlush());
 };
 
+module.exports.VERSION = null;
+
 /** @type{import("../api")} */
 let api = undefined;
 const imported = import("../api.js").then((imported) => {

--- a/packages/solarwinds-apm/src/commonjs/index.d.ts
+++ b/packages/solarwinds-apm/src/commonjs/index.d.ts
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as api from "./api";
+import * as api from "../api";
 export = api;

--- a/packages/solarwinds-apm/src/commonjs/index.js
+++ b/packages/solarwinds-apm/src/commonjs/index.js
@@ -11,5 +11,7 @@ if (require("./version")) {
     );
   }
 
-  module.exports = require("./api");
+  module.exports = require("./api.proxy");
+} else {
+  module.exports = require("./api.noop");
 }

--- a/packages/solarwinds-apm/src/commonjs/version.js
+++ b/packages/solarwinds-apm/src/commonjs/version.js
@@ -6,6 +6,10 @@ var path = require("path");
 var process = require("process");
 var log = require("./log");
 
+var RELEASED = require("./timestamp");
+var NOW = Date.now();
+var YEAR = 1000 * 60 * 60 * 24 * 365;
+
 try {
   if (
     typeof process.version !== "string" ||
@@ -23,49 +27,33 @@ try {
       continue;
     }
 
+    var lts = "lts" in versions[major];
     var eol = new Date(versions[major].end);
 
-    var elapsed = Date.now() - eol.getTime();
-    if (elapsed > 1000 * 60 * 60 * 24 * 365) {
-      var message =
+    var maintained = NOW - eol <= 0;
+    var supported = RELEASED - eol <= (lts ? YEAR : 0);
+
+    if (!maintained) {
+      log(
         "The detected Node.js version (" +
-        process.version +
-        ") has reached End Of Life over one year ago (" +
-        versions[major].end +
-        "). It is no longer supported by this library (solarwinds-apm) and the application will not be instrumented. " +
-        "SolarWinds STRONGLY recommends customers use a non-EOL Node.js version receiving security updates.";
-
-      throw message;
-    } else if (elapsed > 0) {
-      var message =
-        "The detected Node.js version (" +
-        process.version +
-        ") has reached End Of Life (" +
-        versions[major].end +
-        "). It is still supported by this library (solarwinds-apm) for one year following this date. " +
-        "SolarWinds STRONGLY recommends customers use a non-EOL Node.js version receiving security updates.";
-
-      throw message;
+          process.version +
+          ") has reached End Of Life (" +
+          versions[major].end +
+          ")."
+      );
+      log(
+        "SolarWinds STRONGLY recommends customers use a non-EOL Node.js version receiving security updates."
+      );
     }
-  }
-
-  if (process.versions.ares) {
-    if (
-      process.versions.ares &&
-      process.env.GRPC_DNS_RESOLVER &&
-      process.env.GRPC_DNS_RESOLVER.toLowerCase() === "ares"
-    ) {
-      var message =
-        "The current Node.js version is incompatible with the c-ares gRPC DNS resolver, " +
-        "which this application explicitly specifies.";
-
-      throw message;
-    } else {
-      process.env.GRPC_DNS_RESOLVER = "native";
+    if (!supported) {
+      log(
+        "The application will not be instrumented to avoid potential compatibility issues."
+      );
     }
-  }
 
-  module.exports = true;
+    module.exports = supported;
+    break;
+  }
 } catch (error) {
   log(error);
   module.exports = false;

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -65,7 +65,7 @@ import {
 import { componentLogger } from "./shared/logger.js"
 import { VERSION } from "./version.js"
 
-export async function init() {
+export async function init(): Promise<boolean> {
   let config: Configuration
   try {
     config = await read()
@@ -74,7 +74,7 @@ export async function init() {
       "Invalid SolarWinds APM configuration, application will not be instrumented.",
     )
     printError(err)
-    return
+    return false
   }
 
   diag.setLogger(new Logger(), config.logLevel)
@@ -84,12 +84,7 @@ export async function init() {
 
   if (!config.enabled) {
     logger.warn("Library disabled, application will not be instrumented.")
-
-    SAMPLER.resolve(undefined)
-    TRACER_PROVIDER.resolve(undefined)
-    METER_PROVIDER.resolve(undefined)
-    LOGGER_PROVIDER.resolve(undefined)
-    return
+    return false
   }
 
   const registerInstrumentations = await initInstrumentations(config, logger)
@@ -122,6 +117,8 @@ export async function init() {
 
   registerInstrumentations(tracerProvider, meterProvider)
   logger.debug("resource", resource.attributes)
+
+  return true
 }
 
 async function initInstrumentations(config: Configuration, logger: DiagLogger) {

--- a/packages/solarwinds-apm/test/version.js
+++ b/packages/solarwinds-apm/test/version.js
@@ -13,10 +13,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-import base from "@solarwinds-apm/eslint-config"
-
-export default [
-  ...base(),
-  { ignores: ["src/version.ts", "src/commonjs/timestamp.js"] },
-]


### PR DESCRIPTION
Previously the check was done against the current date, but it should have been done against the date the library was built. The check was also too lenient for non-LTS Node releases. This fixes both and adds tests.