### PR TITLE
Migrate to stable semconv for HTTP and set duplicate attributes for others

### DIFF
--- a/.yarn/versions/93ee05f3.yml
+++ b/.yarn/versions/93ee05f3.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: major

--- a/packages/solarwinds-apm/src/init.ts
+++ b/packages/solarwinds-apm/src/init.ts
@@ -45,7 +45,7 @@ import { type Configuration, printError, read } from "./config.js"
 import { environment } from "./env.js"
 import { MetricReader } from "./exporters/metrics.js"
 import { Logger } from "./logger.js"
-import { patch } from "./patches.js"
+import { patch, patchEnv } from "./patches.js"
 import { ParentSpanProcessor } from "./processing/parent-span.js"
 import { ResponseTimeProcessor } from "./processing/response-time.js"
 import { StacktraceProcessor } from "./processing/stacktrace.js"
@@ -86,6 +86,7 @@ export async function init(): Promise<boolean> {
     logger.warn("Library disabled, application will not be instrumented.")
     return false
   }
+  patchEnv(config)
 
   const registerInstrumentations = await initInstrumentations(config, logger)
   const detectors = await getResourceDetectors(

--- a/packages/solarwinds-apm/src/patches.ts
+++ b/packages/solarwinds-apm/src/patches.ts
@@ -169,27 +169,26 @@ const PATCHERS = [
 
 const ENV_PATCHERS = [
   envPatcher(["OTEL_SEMCONV_STABILITY_OPT_IN"], (value) => {
+    const STABLE = ["http"]
+    const DUPLICATE = ["database", "messaging", "k8s"]
+
     const flags =
       value
         ?.split(",")
         .map((f) => f.trim())
         .filter((f) => f !== "") ?? []
-    const explicit = new Set(flags.map((f) => f.split("/")[0]!))
+    const specified = new Set(flags.map((f) => f.split("/")[0]!))
 
-    // stable semconv only for http
-    if (!explicit.has("http")) {
-      flags.push("http")
+    for (const flag of STABLE) {
+      if (!specified.has(flag)) {
+        flags.push(flag)
+      }
     }
 
-    // both stable and experimental for others
-    if (!explicit.has("database")) {
-      flags.push("database/dup")
-    }
-    if (!explicit.has("messaging")) {
-      flags.push("messaging/dup")
-    }
-    if (!explicit.has("k8s")) {
-      flags.push("k8s/dup")
+    for (const flag of DUPLICATE) {
+      if (!specified.has(flag)) {
+        flags.push(`${flag}/dup`)
+      }
     }
 
     return flags.join(",")

--- a/packages/solarwinds-apm/test/patches.test.ts
+++ b/packages/solarwinds-apm/test/patches.test.ts
@@ -24,7 +24,8 @@ import {
 } from "@opentelemetry/api"
 import { afterEach, describe, expect, it } from "@solarwinds-apm/test"
 
-import { type Options, patch } from "../src/patches.js"
+import { type Options, patch, patchEnv } from "../src/patches.js"
+import { Configuration } from "../src/config.js"
 
 class TestResponsePropagator implements TextMapPropagator<unknown> {
   inject(
@@ -531,6 +532,55 @@ describe("patch", () => {
           instrumentation: i,
         })
       }
+    })
+  })
+})
+
+describe("patchEnv", () => {
+  const config = {} as Configuration
+
+  it("sets proper defaults", () => {
+    const env: NodeJS.ProcessEnv = {}
+    patchEnv(config, env)
+
+    expect(env).to.loosely.deep.equal({
+      OTEL_SEMCONV_STABILITY_OPT_IN: "http,database/dup,messaging/dup,k8s/dup",
+    })
+  })
+
+  describe("OTEL_SEMCONV_STABILITY_OPT_IN", () => {
+    it("respects user values", () => {
+      const env: NodeJS.ProcessEnv = {
+        OTEL_SEMCONV_STABILITY_OPT_IN:
+          "http/dup, database, foo, messaging, bar/dup, k8s",
+      }
+      patchEnv(config, env)
+
+      expect(env.OTEL_SEMCONV_STABILITY_OPT_IN).to.equal(
+        "http/dup,database,foo,messaging,bar/dup,k8s",
+      )
+    })
+
+    it("adds database and http if unspecified", () => {
+      const env: NodeJS.ProcessEnv = {
+        OTEL_SEMCONV_STABILITY_OPT_IN: "foo, messaging, bar/dup, k8s",
+      }
+      patchEnv(config, env)
+
+      expect(env.OTEL_SEMCONV_STABILITY_OPT_IN).to.equal(
+        "foo,messaging,bar/dup,k8s,http,database/dup",
+      )
+    })
+
+    it("adds messaging and k8s if unspecified", () => {
+      const env: NodeJS.ProcessEnv = {
+        OTEL_SEMCONV_STABILITY_OPT_IN: "http/dup, database",
+      }
+      patchEnv(config, env)
+
+      expect(env.OTEL_SEMCONV_STABILITY_OPT_IN).to.equal(
+        "http/dup,database,messaging/dup,k8s/dup",
+      )
     })
   })
 })

--- a/packages/solarwinds-apm/test/patches.test.ts
+++ b/packages/solarwinds-apm/test/patches.test.ts
@@ -24,8 +24,8 @@ import {
 } from "@opentelemetry/api"
 import { afterEach, describe, expect, it } from "@solarwinds-apm/test"
 
+import { type Configuration } from "../src/config.js"
 import { type Options, patch, patchEnv } from "../src/patches.js"
-import { Configuration } from "../src/config.js"
 
 class TestResponsePropagator implements TextMapPropagator<unknown> {
   inject(


### PR DESCRIPTION
This is a breaking change for the new release. I initially wanted to also use stable only for database attributes but some of the database instrumentations haven't been updated to the new semconv yet so that will have to be in a future release.

We can add more flags to the duplicate list in the future as more of semconv gets stabilized without it being a breaking change.