### PR TITLE
Fix CommonJS builds

### DIFF
--- a/.yarn/versions/b5a12fbf.yml
+++ b/.yarn/versions/b5a12fbf.yml
@@ -1,0 +1,2 @@
+releases:
+  solarwinds-apm: patch

--- a/packages/solarwinds-apm/build.js
+++ b/packages/solarwinds-apm/build.js
@@ -39,9 +39,6 @@ await fs.writeFile(
   ),
 )
 
-await fs.mkdir("dist/commonjs", { recursive: true })
-await fs.cp("src/commonjs/", "dist/commonjs/", { recursive: true, force: true })
-
 // Generate the web instrumentation bundle to target the Chrome/Safari/Firefox/Edge
 // versions which were the latest 1 year ago as a default
 // People can still bundle themselves if this isn't satisfactory

--- a/packages/solarwinds-apm/build.post.js
+++ b/packages/solarwinds-apm/build.post.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2023-2025 SolarWinds Worldwide, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import fs from "node:fs/promises"
+
+await fs.rm("dist/commonjs", { recursive: true, force: true })
+await fs.mkdir("dist/commonjs", { recursive: true })
+await fs.cp("src/commonjs/", "dist/commonjs/", { recursive: true, force: true })

--- a/packages/solarwinds-apm/package.json
+++ b/packages/solarwinds-apm/package.json
@@ -55,7 +55,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "node build.js && tsc",
+    "build": "node build.js && tsc && node build.post.js",
     "lint": "node build.js && prettier --check . && eslint . --max-warnings=0",
     "lint:fix": "node build.js && eslint --fix . && prettier --write .",
     "release": "node ../../scripts/publish.js",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["build.js", "package.json", "tsconfig.json", "src/**"],
+      "inputs": [
+        "build.js",
+        "build.*.js",
+        "package.json",
+        "tsconfig.json",
+        "src/**"
+      ],
       "outputs": ["dist/**", ".next/**", "COMPATIBILITY.md"]
     },
     "lint": {


### PR DESCRIPTION
They were being overwritten by `tsc` outputs due to a TypeScript update. Now the manually written version always wins.